### PR TITLE
New action playTweenOfEntity(FacingAngle)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -750,6 +750,7 @@ var Server = TaroClass.extend({
 		taro.network.define('devLogs', self._onSomeBullshit);
 		taro.network.define('sound', self._onSomeBullshit);
 		taro.network.define('particle', self._onSomeBullshit);
+		taro.network.define('tween', self._onSomeBullshit);
 		taro.network.define('camera', self._onSomeBullshit);
 		taro.network.define('videoChat', self._onSomeBullshit);
 

--- a/src/client.js
+++ b/src/client.js
@@ -694,6 +694,7 @@ const Client = TaroEventingClass.extend({
 
 		taro.network.define('sound', this._onSound);
 		taro.network.define('particle', this._onParticle);
+		taro.network.define('tween', this._onTween);
 		taro.network.define('camera', this._onCamera);
 
 		taro.network.define('gameSuggestion', this._onGameSuggestion);

--- a/src/gameClasses/ClientNetworkEvents.js
+++ b/src/gameClasses/ClientNetworkEvents.js
@@ -572,7 +572,7 @@ var ClientNetworkEvents = {
 		if (data.entityId) {
 			var entity = taro.$(data.entityId);
 			if (entity) {
-				taro.$(data.entityId).tween.start(data.tweenId, data.angle);
+				entity.tween.start(data.tweenId, data.angle);
 			}
 		}
 	},

--- a/src/gameClasses/ClientNetworkEvents.js
+++ b/src/gameClasses/ClientNetworkEvents.js
@@ -568,6 +568,15 @@ var ClientNetworkEvents = {
 		}
 	},
 
+	_onTween: function (data) {
+		if (data.entityId) {
+			var entity = taro.$(data.entityId);
+			if (entity) {
+				taro.$(data.entityId).tween.start(data.tweenId, data.angle);
+			}
+		}
+	},
+
 	_onCamera: function (data) {
 		// camera zoom change
 		if (data.cmd == "zoom") {

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -2016,8 +2016,11 @@ var ActionComponent = TaroEntity.extend({
 						var entity = self._script.variable.getValue(action.entity, vars);
 						var tweenId = self._script.variable.getValue(action.tween, vars);
 						var angle = self._script.variable.getValue(action.angle, vars);
-						if (entity && !isNaN(angle)) {
-							taro.network.send('tween', { tweenId: tweenId, entityId: entity.id(), angle: angle || 0});
+						if (!angle || isNaN(angle)) {
+							angle = 0;
+						}
+						if (entity) {
+							taro.network.send('tween', { tweenId: tweenId, entityId: entity.id(), angle: angle});
 						}
 
 						break;

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -2012,6 +2012,16 @@ var ActionComponent = TaroEntity.extend({
 
 						break;
 
+					case 'playEntityTween':
+						var entity = self._script.variable.getValue(action.entity, vars);
+						var tweenId = self._script.variable.getValue(action.tween, vars);
+						var angle = self._script.variable.getValue(action.angle, vars);
+						if (entity && !isNaN(angle)) {
+							taro.network.send('tween', { tweenId: tweenId, entityId: entity.id(), angle: angle || 0});
+						}
+
+						break;
+
 					case 'applyForceOnEntityXY':
 					case 'applyForceOnEntityXYLT':
 


### PR DESCRIPTION
This action allow you to play tween of entity.
At the moment you can only play tween in effect tab of the entity which is not flexible.

## Action Details: Play Tween of Entity
Play `tweenId` of `entity` facing `angle(radians)`
** some tweens do not use facing angle (e.g. swingCW and SwingCCW)
** without filling the angle, or set it to undefined, the script will be fine for them 

## Testing Material
[game.txt](https://github.com/moddio/taro2/files/12238266/game.txt)

## Preview
https://github.com/moddio/taro2/assets/62375288/9e94c4aa-f6a3-42ae-a2f5-12dd44866227

When you press space
- your unit has swingCCW tween
- your holding item have poke tween (angle is facing angle of your unit + 3.1416)
