### PR TITLE
Allow "!" for commands

### DIFF
--- a/engine/components/chat/TaroChatServer.js
+++ b/engine/components/chat/TaroChatServer.js
@@ -99,7 +99,7 @@ var TaroChatServer = {
 		}
 
 		// do not show command messages that start with '/'. e.g. /ban user
-		if (message != undefined && message[0] == '/') {
+		if (message != undefined && message[0] == '/' || message[0] == '!') {
 			return;
 		}
 


### PR DESCRIPTION
Currently commands are limited to "/" commands as only forward slashes get hidden. This adds exclamation marks as a command starter as it's common for games to use this for commands