### PR TITLE
fix: don't destroyObj which is not created by new

### DIFF
--- a/engine/components/physics/box2d/Box2dComponent.js
+++ b/engine/components/physics/box2d/Box2dComponent.js
@@ -282,7 +282,6 @@ var PhysicsComponent = TaroEventingClass.extend({
 							var entity = taro.$(entityId);
 							entities.push(taro.$(entityId));
 						}
-						self.destroyB2dObj(fixture_p);
 						return true;
 					}
 				});


### PR DESCRIPTION
## Summary
- fix the box2dwasm will try to destroy an obj which is not created by new