### PR TITLE
Add multiple tileset support to voxel map

### DIFF
--- a/src/ClientConfig.js
+++ b/src/ClientConfig.js
@@ -125,6 +125,7 @@ var taroClientConfig = {
 		'renderer/three/ThreeUnit.js',
 		'renderer/three/ThreeAttributeBar.js',
 		'renderer/three/ThreeChatBubble.js',
+		'renderer/three/ThreeTileset.js',
 
 		'/client.js',
 		'/index.js',

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -61,7 +61,6 @@ class ThreeRenderer {
 		};
 
 		THREE.DefaultLoadingManager.onLoad = () => {
-			console.log(ThreeTextureManager.instance().textureMap);
 			this.init();
 			this.setupInputListeners();
 			taro.client.rendererLoaded.resolve();
@@ -150,50 +149,46 @@ class ThreeRenderer {
 		}
 
 		taro.game.data.map.tilesets.forEach((tileset) => {
+			// TODO: Add tilesets to resource manager (rename texture manager to resource manager)
 			const tex = ThreeTextureManager.instance().textureMap.get(tileset.image);
-			const cols = Math.floor(tex.image.width / tileset.tilewidth);
-
-			tex.image = resizeImageToPowerOf2(tex.image);
-			tex.generateMipmaps = false;
-
-			this.voxelMap = new ThreeVoxelMap(tex, tileset.tilewidth, tileset.tileheight, cols);
+			this.voxelMap = new ThreeVoxelMap(new ThreeTileset(tex, tileset.tilewidth, tileset.tilewidth));
 			this.scene.add(this.voxelMap);
+		});
 
-			taro.game.data.map.layers.forEach((layer) => {
-				let layerId = 0;
-				switch (layer.name) {
-					case 'floor':
-						layerId = 1;
-						break;
-					case 'floor2':
-						layerId = 2;
-						break;
-					case 'walls':
-						layerId = 3;
-						break;
-					case 'trees':
-						// 5 so it's always rendered on top.
-						// label/bars are rendered at renderOrder 499
-						layerId = 5;
-						break;
-				}
+		taro.game.data.map.layers.forEach((layer) => {
+			let layerId = 0;
+			switch (layer.name) {
+				case 'floor':
+					layerId = 1;
+					break;
+				case 'floor2':
+					layerId = 2;
+					break;
+				case 'walls':
+					layerId = 3;
+					break;
+				case 'trees':
+					// 5 so it's always rendered on top.
+					// label/bars are rendered at renderOrder 499
+					layerId = 5;
+					break;
+			}
 
-				if (['floor'].includes(layer.name)) {
-					this.voxelMap.addLayer(layer, 0, false, false, layerId * 100);
-				}
+			if (['floor'].includes(layer.name)) {
+				this.voxelMap.addLayer(layer, 0, false, false, layerId * 100);
+			}
 
-				if (['floor2'].includes(layer.name)) {
-					this.voxelMap.addLayer(layer, 1, true, true, layerId * 100);
-				}
+			if (['floor2'].includes(layer.name)) {
+				this.voxelMap.addLayer(layer, 1, true, true, layerId * 100);
+			}
 
-				if (['walls'].includes(layer.name)) {
-					this.voxelMap.addLayer(layer, 1, true, false, layerId * 100);
-				}
+			if (['walls'].includes(layer.name)) {
+				this.voxelMap.addLayer(layer, 1, true, false, layerId * 100);
+			}
 
-				if (['trees'].includes(layer.name)) {
-					this.voxelMap.addLayer(layer, 3, true, true, layerId * 100);
-				}
-			});
+			if (['trees'].includes(layer.name)) {
+				this.voxelMap.addLayer(layer, 3, true, true, layerId * 100);
+			}
 		});
 
 		const createEntity = (entity: Unit | Item | Projectile) => {
@@ -448,21 +443,4 @@ class ThreeRenderer {
 			});
 		}
 	}
-}
-
-function resizeImageToPowerOf2(image) {
-	const ceil = THREE.MathUtils.ceilPowerOfTwo;
-
-	const width = ceil(image.width);
-	const height = ceil(image.height);
-
-	const canvas = document.createElement('canvas');
-
-	canvas.width = width;
-	canvas.height = height;
-
-	const context = canvas.getContext('2d');
-	context.drawImage(image, 0, 0, width, height, 0, 0, width, height);
-
-	return canvas;
 }

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -151,7 +151,10 @@ class ThreeRenderer {
 		taro.game.data.map.tilesets.forEach((tileset) => {
 			// TODO: Add tilesets to resource manager (rename texture manager to resource manager)
 			const tex = ThreeTextureManager.instance().textureMap.get(tileset.image);
-			this.voxelMap = new ThreeVoxelMap(new ThreeTileset(tex, tileset.tilewidth, tileset.tilewidth));
+			// TODO: The sides tileset will be different, waiting on m0dE
+			const topTileset = new ThreeTileset(tex, tileset.tilewidth, tileset.tilewidth);
+			const sidesTileset = new ThreeTileset(tex, tileset.tilewidth, tileset.tilewidth);
+			this.voxelMap = new ThreeVoxelMap(topTileset, sidesTileset);
 			this.scene.add(this.voxelMap);
 		});
 

--- a/ts/src/renderer/three/ThreeTileset.ts
+++ b/ts/src/renderer/three/ThreeTileset.ts
@@ -1,0 +1,38 @@
+class ThreeTileset {
+	originalWidth: number;
+	originalHeight: number;
+	columns: number;
+	width: number;
+	height: number;
+
+	constructor(
+		public texture: THREE.Texture,
+		public tileWidth: number,
+		public tileHeight: number
+	) {
+		this.originalWidth = texture.image.width;
+		this.originalHeight = texture.image.height;
+		this.columns = Math.floor(texture.image.width / tileWidth);
+		texture.image = resizeImageToPowerOf2(texture.image);
+		this.width = texture.image.width;
+		this.height = texture.image.height;
+		texture.generateMipmaps = false;
+	}
+}
+
+function resizeImageToPowerOf2(image) {
+	const ceil = THREE.MathUtils.ceilPowerOfTwo;
+
+	const width = ceil(image.width);
+	const height = ceil(image.height);
+
+	const canvas = document.createElement('canvas');
+
+	canvas.width = width;
+	canvas.height = height;
+
+	const context = canvas.getContext('2d');
+	context.drawImage(image, 0, 0, width, height, 0, 0, width, height);
+
+	return canvas;
+}

--- a/ts/src/renderer/three/ThreeTileset.ts
+++ b/ts/src/renderer/three/ThreeTileset.ts
@@ -13,26 +13,9 @@ class ThreeTileset {
 		this.originalWidth = texture.image.width;
 		this.originalHeight = texture.image.height;
 		this.columns = Math.floor(texture.image.width / tileWidth);
-		texture.image = resizeImageToPowerOf2(texture.image);
+		texture.image = Utils.resizeImageToPowerOf2(texture.image);
 		this.width = texture.image.width;
 		this.height = texture.image.height;
 		texture.generateMipmaps = false;
 	}
-}
-
-function resizeImageToPowerOf2(image) {
-	const ceil = THREE.MathUtils.ceilPowerOfTwo;
-
-	const width = ceil(image.width);
-	const height = ceil(image.height);
-
-	const canvas = document.createElement('canvas');
-
-	canvas.width = width;
-	canvas.height = height;
-
-	const context = canvas.getContext('2d');
-	context.drawImage(image, 0, 0, width, height, 0, 0, width, height);
-
-	return canvas;
 }

--- a/ts/src/renderer/three/ThreeVoxelMap.ts
+++ b/ts/src/renderer/three/ThreeVoxelMap.ts
@@ -191,8 +191,8 @@ function buildMeshDataFromCells(cells, tileset: ThreeTileset) {
 				localIndices[j] += bi;
 			}
 
-			// top face (positive-y)
-			if (i === 2) {
+			// top and bottom face
+			if (i === 2 || i === 3) {
 				targetData.topIndices.push(...localIndices);
 			} else {
 				targetData.sidesIndices.push(...localIndices);

--- a/ts/src/renderer/three/ThreeVoxelMap.ts
+++ b/ts/src/renderer/three/ThreeVoxelMap.ts
@@ -1,5 +1,8 @@
 class ThreeVoxelMap extends THREE.Group {
-	constructor(private tileset: ThreeTileset) {
+	constructor(
+		private topTileset: ThreeTileset,
+		private sidesTileset: ThreeTileset
+	) {
 		super();
 	}
 
@@ -29,20 +32,21 @@ class ThreeVoxelMap extends THREE.Group {
 		}
 
 		const prunedVoxels = pruneCells(voxels);
-		const voxelData = buildMeshDataFromCells(prunedVoxels, this.tileset);
+		const voxelData = buildMeshDataFromCells(prunedVoxels, this.topTileset);
 
 		const geometry = new THREE.BufferGeometry();
-		geometry.setIndex([...voxelData.otherIndices, ...voxelData.topIndices]);
+		geometry.setIndex([...voxelData.sidesIndices, ...voxelData.topIndices]);
 		geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(voxelData.positions), 3));
 		geometry.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(voxelData.uvs), 2));
 		geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(voxelData.normals), 3));
-		const mat1 = new THREE.MeshBasicMaterial({ transparent, map: this.tileset.texture, side: THREE.DoubleSide });
-		const mat2 = new THREE.MeshBasicMaterial({ transparent, map: this.tileset.texture, side: THREE.DoubleSide });
+
+		const mat1 = new THREE.MeshBasicMaterial({ transparent, map: this.sidesTileset.texture, side: THREE.DoubleSide });
+		const mat2 = new THREE.MeshBasicMaterial({ transparent, map: this.topTileset.texture, side: THREE.DoubleSide });
+
+		geometry.addGroup(0, voxelData.sidesIndices.length, 0);
+		geometry.addGroup(voxelData.sidesIndices.length, voxelData.topIndices.length, 1);
+
 		const mesh = new THREE.Mesh(geometry, [mat1, mat2]);
-
-		geometry.addGroup(0, voxelData.otherIndices.length, 0);
-		geometry.addGroup(voxelData.otherIndices.length, voxelData.topIndices.length, 1);
-
 		mesh.renderOrder = renderOrder;
 
 		this.add(mesh);
@@ -122,7 +126,7 @@ function buildMeshDataFromCells(cells, tileset: ThreeTileset) {
 		uvs: [],
 		normals: [],
 		topIndices: [],
-		otherIndices: [],
+		sidesIndices: [],
 	};
 
 	for (let c of cells.keys()) {
@@ -191,7 +195,7 @@ function buildMeshDataFromCells(cells, tileset: ThreeTileset) {
 			if (i === 2) {
 				targetData.topIndices.push(...localIndices);
 			} else {
-				targetData.otherIndices.push(...localIndices);
+				targetData.sidesIndices.push(...localIndices);
 			}
 		}
 	}

--- a/ts/src/renderer/three/utils.ts
+++ b/ts/src/renderer/three/utils.ts
@@ -122,4 +122,21 @@ namespace Utils {
 	export function pixelToWorld(numPixels: number) {
 		return numPixels / 64;
 	}
+
+	export function resizeImageToPowerOf2(image) {
+		const ceil = THREE.MathUtils.ceilPowerOfTwo;
+
+		const width = ceil(image.width);
+		const height = ceil(image.height);
+
+		const canvas = document.createElement('canvas');
+
+		canvas.width = width;
+		canvas.height = height;
+
+		const context = canvas.getContext('2d');
+		context.drawImage(image, 0, 0, width, height, 0, 0, width, height);
+
+		return canvas;
+	}
 }

--- a/ts/types/GameComponent.d.ts
+++ b/ts/types/GameComponent.d.ts
@@ -94,7 +94,6 @@ interface MapData {
 		tilecount: number;
 		tileheight: number;
 		tilewidth: number;
-		columns: number;
 	}[];
 	layers: {
 		y: number;


### PR DESCRIPTION
Allows 2 tilesets to be set for the voxel map. One for the top/bottom faces of the voxels and the other for the side faces. The UI that hooks up to this feature still has to be implemented.