### PR TITLE
Turn flat layers into voxel layers

### DIFF
--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -161,7 +161,7 @@ class ThreeRenderer {
 			entities: new THREE.Group(),
 		};
 
-		layers.entities.position.y = 1;
+		layers.entities.position.y = 0.51;
 
 		for (const layer of Object.values(layers)) {
 			this.scene.add(layer);
@@ -209,7 +209,7 @@ class ThreeRenderer {
 			}
 
 			if (['trees'].includes(layer.name)) {
-				this.voxelMap.addLayer(layer, 3, true, false, layerId * 100);
+				this.voxelMap.addLayer(layer, 2, true, false, layerId * 100);
 			}
 		});
 
@@ -230,7 +230,7 @@ class ThreeRenderer {
 			const transformEvtListener = entity.on(
 				'transform',
 				(data: { x: number; y: number; rotation: number }) => {
-					ent.position.set(Utils.pixelToWorld(data.x) - 0.5, 1, Utils.pixelToWorld(data.y) - 0.5);
+					ent.position.set(Utils.pixelToWorld(data.x) - 0.5, 0, Utils.pixelToWorld(data.y) - 0.5);
 
 					let angle = -data.rotation;
 					if (ent.billboard && (entity instanceof Item || entity instanceof Projectile)) {

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -201,7 +201,7 @@ class ThreeRenderer {
 			}
 
 			if (['floor2'].includes(layer.name)) {
-				this.voxelMap.addLayer(layer, 1, true, true, layerId * 100);
+				this.voxelMap.addLayer(layer, 1, true, false, layerId * 100);
 			}
 
 			if (['walls'].includes(layer.name)) {
@@ -209,7 +209,7 @@ class ThreeRenderer {
 			}
 
 			if (['trees'].includes(layer.name)) {
-				this.voxelMap.addLayer(layer, 3, true, true, layerId * 100);
+				this.voxelMap.addLayer(layer, 3, true, false, layerId * 100);
 			}
 		});
 

--- a/ts/src/renderer/three/ThreeSprite.ts
+++ b/ts/src/renderer/three/ThreeSprite.ts
@@ -14,7 +14,7 @@ class ThreeSprite extends THREE.Group {
 
 		const geometry = new THREE.PlaneGeometry(1, 1);
 		geometry.rotateX(-Math.PI / 2);
-		const material = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
+		const material = new THREE.MeshBasicMaterial({ map: tex, transparent: true, depthWrite: false });
 		this.sprite = new THREE.Mesh(geometry, material);
 		this.add(this.sprite);
 


### PR DESCRIPTION
- Turn the flat map layers into voxel layers
- Lower the vertical position of the trees layer and entities
- Fix z-fighting between sprites with the same vertical position