### PR TITLE
A* Pathfinding Bug Fix and Enhancement

### DIFF
--- a/src/gameClasses/components/unit/AIComponent.js
+++ b/src/gameClasses/components/unit/AIComponent.js
@@ -177,11 +177,11 @@ var AIComponent = TaroEntity.extend({
 
 	getDistanceToClosestAStarNode: function () {
 		let distance = 0;
-		let mapData = taro.map.data;
+		const tileWidth = taro.scaleMapDetails.tileWidth;
 		let unit = this._entity;
 		if (this.path.length > 0) { // closestAStarNode exist
-			let a = this.path[this.path.length - 1].x * mapData.tilewidth + mapData.tilewidth / 2 - unit._translate.x;
-			let b = this.path[this.path.length - 1].y * mapData.tilewidth + mapData.tilewidth / 2 - unit._translate.y;
+			let a = this.path[this.path.length - 1].x * tileWidth + tileWidth / 2 - unit._translate.x;
+			let b = this.path[this.path.length - 1].y * tileWidth + tileWidth / 2 - unit._translate.y;
 			distance = Math.sqrt(a * a + b * b);
 		}
 		return distance;
@@ -317,12 +317,13 @@ var AIComponent = TaroEntity.extend({
 		let returnValue = { path: [], ok: false };
 		let unit = this._entity;
 
-		let mapData = taro.map.data; // cache the map data for rapid use
+		const mapData = taro.map.data; // cache the map data for rapid use
+		const tileWidth = taro.scaleMapDetails.tileWidth;
 
-		let unitTilePosition = {x: Math.floor(unit._translate.x / mapData.tilewidth), y: Math.floor(unit._translate.y / mapData.tilewidth)};
+		let unitTilePosition = {x: Math.floor(unit._translate.x / tileWidth), y: Math.floor(unit._translate.y / tileWidth)};
 		unitTilePosition.x = Math.min(Math.max(0, unitTilePosition.x), mapData.width - 1); // confine with map boundary
 		unitTilePosition.y = Math.min(Math.max(0, unitTilePosition.y), mapData.height - 1);
-		let targetTilePosition = {x: Math.floor(x / mapData.tilewidth), y: Math.floor(y / mapData.tilewidth)};
+		let targetTilePosition = {x: Math.floor(x / tileWidth), y: Math.floor(y / tileWidth)};
 		targetTilePosition.x = Math.min(Math.max(0, targetTilePosition.x), mapData.width - 1); // confine with map boundary
 		targetTilePosition.y = Math.min(Math.max(0, targetTilePosition.y), mapData.height - 1);
 		
@@ -332,7 +333,7 @@ var AIComponent = TaroEntity.extend({
 			return returnValue;
 		}
 
-		let wallMap = taro.map.wallMap; // wall layer cached
+		const wallMap = taro.map.wallMap; // wall layer cached
 		let openList = []; // store grid nodes that is under evaluation
 		let closeList = []; // store grid nodes that finished evaluation
 		let tempPath = []; // store path to return (smaller index: closer to target, larger index: closer to start)
@@ -483,8 +484,8 @@ var AIComponent = TaroEntity.extend({
 	},
 
 	aStarPathIsBlocked: function() {
-		let mapData = taro.map.data;
-		let wallMap = taro.map.wallMap;
+		const mapData = taro.map.data;
+		const wallMap = taro.map.wallMap;
 		let result = false;
 
 		for (let i = 0; i < this.path.length; i++) {
@@ -498,14 +499,14 @@ var AIComponent = TaroEntity.extend({
 	},
 
 	aStarTargetIsCloser: function (unit, targetUnit) {
-		let mapData = taro.map.data;
+		const tileWidth = taro.scaleMapDetails.tileWidth;
 
 		let a = targetUnit._translate.x - unit._translate.x;
 		let b = targetUnit._translate.y - unit._translate.y;
 		let distanceToTarget = Math.sqrt(a * a + b * b);
 		
-		let c = this.path[0].x * mapData.tilewidth + mapData.tilewidth / 2 - unit._translate.x;
-		let d = this.path[0].y * mapData.tilewidth + mapData.tilewidth / 2 - unit._translate.y;
+		let c = this.path[0].x * tileWidth + tileWidth / 2 - unit._translate.x;
+		let d = this.path[0].y * tileWidth + tileWidth / 2 - unit._translate.y;
 		let distanceToEndPath = Math.sqrt(c * c + d * d);
 
 		return distanceToTarget < distanceToEndPath;
@@ -548,7 +549,7 @@ var AIComponent = TaroEntity.extend({
 		if (!unit._stats.aiEnabled)
 			return;
 
-		let mapData = taro.map.data; // both pathfinding method need it to check
+		const tileWidth = taro.scaleMapDetails.tileWidth; // both pathfinding method need it to check
 		
 		var targetUnit = this.getTargetUnit();
 
@@ -584,17 +585,17 @@ var AIComponent = TaroEntity.extend({
 			case 'move':
 				switch (this.pathFindingMethod) {
 					case 'simple':
-						if (this.getDistanceToTarget() < mapData.tilewidth / 2) { // map with smaller tile size requires a more precise stop, vice versa
+						if (this.getDistanceToTarget() < tileWidth / 2) { // map with smaller tile size requires a more precise stop, vice versa
 							self.goIdle();
 						}
 						break;
 					case 'a*':
-						if (this.getDistanceToClosestAStarNode() < mapData.tilewidth / 2) { // reduced chances of shaky move
+						if (this.getDistanceToClosestAStarNode() < tileWidth / 2) { // reduced chances of shaky move
 							this.path.pop(); // after moved to the closest A* node, pop the array and let ai move to next A* node
 						}
 						if (this.path.length > 0) { // Move to the highest index of path saved (closest node to start node)
 							if (!this.aStarPathIsBlocked()) { // only keep going if the path is still non blocked
-								this.setTargetPosition(this.path[this.path.length - 1].x * mapData.tilewidth + mapData.tilewidth / 2, this.path[this.path.length - 1].y * mapData.tilewidth + mapData.tilewidth / 2);
+								this.setTargetPosition(this.path[this.path.length - 1].x * tileWidth + tileWidth / 2, this.path[this.path.length - 1].y * tileWidth + tileWidth / 2);
 							} else { 
 								let aStarResult = this.getAStarPath(this.path[0].x, this.path[0].y); // recalculate whole path once the next move is blocked
 								this.path = aStarResult.path;
@@ -661,13 +662,13 @@ var AIComponent = TaroEntity.extend({
 										this.onAStarFailedTrigger();
 										break;
 									}
-								} else if (this.getDistanceToClosestAStarNode() < mapData.tilewidth / 2) { // Euclidean distance is smaller than half of the tile
+								} else if (this.getDistanceToClosestAStarNode() < tileWidth / 2) { // Euclidean distance is smaller than half of the tile
 									this.path.pop();
 								}
 								// After the above decision, choose whether directly move to targetUnit or according to path
 								if (this.path.length > 0) { // select next node to go
 									if (!this.aStarPathIsBlocked() && !this.aStarTargetIsCloser(unit, targetUnit)) { // keep going if the path is still non blocked OR target is actually closer than end node
-										this.setTargetPosition(this.path[this.path.length - 1].x * mapData.tilewidth + mapData.tilewidth / 2, this.path[this.path.length - 1].y * mapData.tilewidth + mapData.tilewidth / 2);
+										this.setTargetPosition(this.path[this.path.length - 1].x * tileWidth + tileWidth / 2, this.path[this.path.length - 1].y * tileWidth + tileWidth / 2);
 									} else { 
 										let aStarResult = this.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate whole path once the next move is blocked
 										this.path = aStarResult.path;

--- a/src/gameClasses/components/unit/AIComponent.js
+++ b/src/gameClasses/components/unit/AIComponent.js
@@ -393,31 +393,31 @@ var AIComponent = TaroEntity.extend({
 								
 				if (wallMap[newPosition.x + newPosition.y * mapData.width] != 0) continue;// node inside wall, discard				
 				// if new position is not goal, prune it if wall overlaps
-					let shouldPrune = false;
-					for (let i = 1; i <= averageTileShift; i++) {
-						// check 8 direction of average tile shift to see will unit overlap with wall at that node
-						
-						let cornersHaveWallCurrent = (
-							wallMap[minNode.current.x + i + minNode.current.y * mapData.width] != 0 || wallMap[minNode.current.x - i + minNode.current.y * mapData.width] != 0 ||
-							wallMap[minNode.current.x + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + (minNode.current.y - i) * mapData.width] != 0
-						);
-						let sidesHaveWallCurrent = (
-							wallMap[minNode.current.x + i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x - i + (minNode.current.y - i) * mapData.width] != 0 ||
-							wallMap[minNode.current.x - i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + i + (minNode.current.y - i) * mapData.width]
-						);
-						let cornersHaveWallNew = (
-							wallMap[newPosition.x + i + newPosition.y * mapData.width] != 0 || wallMap[newPosition.x - i + newPosition.y * mapData.width] != 0 ||
-							wallMap[newPosition.x + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + (newPosition.y - i) * mapData.width] != 0
-						);
-						let sidesHaveWallNew = (
-							wallMap[newPosition.x + i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x - i + (newPosition.y - i) * mapData.width] != 0 ||
-							wallMap[newPosition.x - i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + i + (newPosition.y - i) * mapData.width]
-						);
-						// Idea: avoid hitting outer corners of wall(dodge by going outer), and allow unit to walk next to walls
-						shouldPrune = (cornersHaveWallNew || sidesHaveWallNew) && (cornersHaveWallCurrent || sidesHaveWallCurrent) && !(cornersHaveWallNew && sidesHaveWallNew && cornersHaveWallCurrent && sidesHaveWallCurrent);
-						if (shouldPrune) break;
-					}
-					if (shouldPrune) continue;
+				let shouldPrune = false;
+				for (let i = 1; i <= averageTileShift; i++) {
+					// check 8 direction of average tile shift to see will unit overlap with wall at that node					
+					let cornersHaveWallCurrent = (
+						wallMap[minNode.current.x + i + minNode.current.y * mapData.width] != 0 || wallMap[minNode.current.x - i + minNode.current.y * mapData.width] != 0 ||
+						wallMap[minNode.current.x + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + (minNode.current.y - i) * mapData.width] != 0
+					);
+					let sidesHaveWallCurrent = (
+						wallMap[minNode.current.x + i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x - i + (minNode.current.y - i) * mapData.width] != 0 ||
+						wallMap[minNode.current.x - i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + i + (minNode.current.y - i) * mapData.width]
+					);
+					let cornersHaveWallNew = (
+						wallMap[newPosition.x + i + newPosition.y * mapData.width] != 0 || wallMap[newPosition.x - i + newPosition.y * mapData.width] != 0 ||
+						wallMap[newPosition.x + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + (newPosition.y - i) * mapData.width] != 0
+					);
+					let sidesHaveWallNew = (
+						wallMap[newPosition.x + i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x - i + (newPosition.y - i) * mapData.width] != 0 ||
+						wallMap[newPosition.x - i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + i + (newPosition.y - i) * mapData.width]
+					);
+
+					// Idea: avoid hitting outer corners of wall(dodge by going outer), and allow unit to walk next to walls
+					shouldPrune = (cornersHaveWallNew || sidesHaveWallNew) && (cornersHaveWallCurrent || sidesHaveWallCurrent) && !(cornersHaveWallNew && sidesHaveWallNew && cornersHaveWallCurrent && sidesHaveWallCurrent);
+					if (shouldPrune) break;
+				}
+				if (shouldPrune) continue;
 
 				if (!isNaN(parseInt(this.maxTravelDistance))) {
 					// new Position is way too far from current position (> maxTravelDistance * 5 of unit, total diameter: 10 maxTravelDistance), hence A Star skip this possible node


### PR DESCRIPTION
## What's new
- Fix issue that A* AI corrupted when map tile size is force scale to 64x64 whereas its original tile size isn't
- Enhanced A*IsPositionBlocked logic
  - Now it checks corners instead of sides
  - (i.e. TL, TR, BL, BR instead of T, D, L, R)
- A* will now it take care unit size as well
- Resolved some deadzone and bug related to new A* code that take care unit size


## !!! Important
- since it take care unit size
- if a node is too close to wall (i.e. when that node as unit center the unit will collide with a wall) then that node will be invalid
- it will throw A* fail trigger immediately
- this may only affect games with crowd roads but large units (unit size < tileWidth is not supposed to be affected)


https://github.com/moddio/moddio2/assets/62375288/eeceaf58-f27b-4ae9-b517-0e42b50020c4

