### PR TITLE
Camera config integration

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -315,7 +315,7 @@ const Client = TaroEventingClass.extend({
 		Object.keys(skyboxDefaultUrls).forEach((key) => {
 			if (taro.game.data.settings.skybox[key] === undefined) {
 				taro.game.data.settings.skybox[key] = skyboxDefaultUrls[key];
-			} 
+			}
 		});
 	},
 

--- a/ts/src/renderer/three/ThreeCamera.ts
+++ b/ts/src/renderer/three/ThreeCamera.ts
@@ -19,8 +19,23 @@ class ThreeCamera {
 	private onChangeCbs = [];
 
 	constructor(viewportWidth: number, viewportHeight: number, canvas: HTMLCanvasElement) {
+		// Public API
+
+		// DONE
+		// camera.setProjection(string)
+		// camera.setElevationAngle(number)
+		// camera.setAzimuthAngle(number)
+
+		// TODO
+		// camera.setTarget(object3d | null, moveInstantOrLerp)
+		// camera.setPointerLock(bool)
+		// camera.setPitchRange(min, max)
+		// camera.setScreenOffset(x, y)
+		// camera.setZoom(number)
+		// camera.setFollowSpeed(number)
+		// camera.update(dt <--)
+
 		const persCamera = new THREE.PerspectiveCamera(75, viewportWidth / viewportHeight, 0.1, 15000);
-		persCamera.position.y = 1;
 		this.perspectiveCamera = persCamera;
 		this.fovInitial = Math.tan(((Math.PI / 180) * this.perspectiveCamera.fov) / 2);
 		this.viewportHeightInitial = viewportHeight;
@@ -28,8 +43,13 @@ class ThreeCamera {
 		const halfWidth = Utils.pixelToWorld(viewportWidth / 2);
 		const halfHeight = Utils.pixelToWorld(viewportHeight / 2);
 		const orthoCamera = new THREE.OrthographicCamera(-halfWidth, halfWidth, halfHeight, -halfHeight, -2000, 15000);
-		orthoCamera.position.y = 1;
 		this.orthographicCamera = orthoCamera;
+
+		const yFovDeg = this.perspectiveCamera.fov * (Math.PI / 180);
+		const distance =
+			this.orthographicCamera.top / Math.tan(yFovDeg * 0.5) / (this.orthographicCamera.zoom / this.zoomLevel);
+		this.perspectiveCamera.position.y = distance;
+		this.orthographicCamera.position.y = distance;
 
 		this.instance = orthoCamera;
 
@@ -95,6 +115,11 @@ class ThreeCamera {
 		info.style.opacity = '0.75';
 		info.style.marginTop = '40px';
 		this.debugInfo = info;
+	}
+
+	setProjection(projection: typeof taro.game.data.settings.camera.projectionMode) {
+		if (projection === 'orthographic') this.switchToOrthographicCamera();
+		else if (projection === 'perspective') this.switchToPerspectiveCamera();
 	}
 
 	setElevationAngle(deg: number) {

--- a/ts/src/renderer/three/ThreeCamera.ts
+++ b/ts/src/renderer/three/ThreeCamera.ts
@@ -28,11 +28,11 @@ class ThreeCamera {
 		// camera.setElevationAngle(number)
 		// camera.setAzimuthAngle(number)
 		// camera.setOffset(x, y, z)
+		// camera.setElevationRange(min, max)
 
 		// TODO
 		// camera.setTarget(object3d | null, moveInstantOrLerp)
 		// camera.setPointerLock(bool)
-		// camera.setPitchRange(min, max)
 		// camera.setZoom(number)
 		// camera.setFollowSpeed(number)
 		// camera.update(dt <--)
@@ -193,6 +193,14 @@ class ThreeCamera {
 
 	setOffset(x: number, y: number, z: number) {
 		this.offset.set(x, y, z);
+	}
+
+	setElevationRange(min: number, max: number) {
+		const minRad = min * (Math.PI / 180);
+		const maxRad = max * (Math.PI / 180);
+		this.controls.maxPolarAngle = Math.PI * 0.5 - minRad;
+		this.controls.minPolarAngle = Math.PI * 0.5 - maxRad;
+		this.controls.update();
 	}
 
 	update() {

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -225,6 +225,19 @@ class ThreeRenderer {
 				const e = new ThreeUnit(tex.clone());
 				this.animatedSprites.push(e);
 				e.billboard = !!entity._stats.isBillboard;
+
+				if (entity._stats.cameraPointerLock) {
+					e.cameraConfig.pointerLock = entity._stats.cameraPointerLock;
+				}
+
+				if (entity._stats.cameraPitchRange) {
+					e.cameraConfig.pitchRange = entity._stats.cameraPitchRange;
+				}
+
+				if (entity._stats.cameraOffset) {
+					e.cameraConfig.offset = entity._stats.cameraOffset;
+				}
+
 				return e;
 			};
 

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -37,17 +37,9 @@ class ThreeRenderer {
 		this.camera = new ThreeCamera(width, height, this.renderer.domElement);
 		this.camera.setElevationAngle(90);
 
-		// camera.setTarget(object3d | null, moveInstantOrNot)
-		// camera.setPerspective()
-		// camera.setOrthographic()
-		// camera.setPointerLock()
-		// camera.setElevationAngle()
-		// camera.setAzimuthAngle()
-		// camera.setPitchRange()
-		// camera.setScreenOffset()
-		// camera.setZoom()
-		// camera.setFollowSpeed()
-		// camera.update(dt)
+		if (taro.game.data.settings.camera.projectionMode !== 'orthographic') {
+			this.camera.setProjection(taro.game.data.settings.camera.projectionMode);
+		}
 
 		this.scene = new THREE.Scene();
 		this.scene.translateX(-taro.game.data.map.width / 2);

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -235,7 +235,10 @@ class ThreeRenderer {
 				}
 
 				if (entity._stats.cameraOffset) {
-					e.cameraConfig.offset = entity._stats.cameraOffset;
+					// From editor XZY to Three.js XYZ
+					e.cameraConfig.offset.x = entity._stats.cameraOffset.x;
+					e.cameraConfig.offset.y = entity._stats.cameraOffset.z;
+					e.cameraConfig.offset.z = entity._stats.cameraOffset.y;
 				}
 
 				return e;
@@ -299,6 +302,9 @@ class ThreeRenderer {
 					this.camera.startFollow(ent);
 					this.skybox.scene.position.copy(ent.position);
 					ent.attach(this.skybox.scene);
+
+					const offset = ent.cameraConfig.offset;
+					this.camera.setOffset(offset.x, offset.y, offset.z);
 				},
 				this
 			);

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -305,6 +305,11 @@ class ThreeRenderer {
 
 					const offset = ent.cameraConfig.offset;
 					this.camera.setOffset(offset.x, offset.y, offset.z);
+
+					if (ent.cameraConfig.pointerLock) {
+						const { min, max } = ent.cameraConfig.pitchRange;
+						this.camera.setElevationRange(min, max);
+					}
 				},
 				this
 			);

--- a/ts/src/renderer/three/ThreeUnit.ts
+++ b/ts/src/renderer/three/ThreeUnit.ts
@@ -1,6 +1,12 @@
 class ThreeUnit extends ThreeAnimatedSprite {
 	label = new ThreeLabel();
 
+	cameraConfig = {
+		pointerLock: false,
+		pitchRange: { min: -90, max: 90 },
+		offset: { x: 0, y: 0, z: 0 },
+	};
+
 	private attributeBars = new THREE.Group();
 	private chat: ThreeChatBubble;
 

--- a/ts/types/EntityStats.d.ts
+++ b/ts/types/EntityStats.d.ts
@@ -54,4 +54,7 @@ declare interface EntityStats {
 		unitAbilities: Record<string, UnitAbility>;
 	};
 	ownerUnitId: string;
+	cameraPointerLock?: boolean;
+	cameraPitchRange?: { min: number; max: number };
+	cameraOffset?: { x: number; y: number; z: number };
 }

--- a/ts/types/GameComponent.d.ts
+++ b/ts/types/GameComponent.d.ts
@@ -138,6 +138,7 @@ declare class GameComponent extends TaroEntity {
 					width: number;
 					height: number;
 				};
+				projectionMode: 'orthographic' | 'perspective';
 			};
 			skybox: {
 				left: string;


### PR DESCRIPTION
This PR:

- Sets the camera projection from the editor settings.
- Sets the camera offset from the camera settings of the unit the camera is following.
- Sets the camera pitch range from the camera settings of the unit the camera is following if pointer lock is enabled.

Note: Pointer lock is not yet implemented.