### PR TITLE
Make billboard sprites face camera on creation

### DIFF
--- a/ts/src/renderer/three/ThreeSprite.ts
+++ b/ts/src/renderer/three/ThreeSprite.ts
@@ -18,14 +18,18 @@ class ThreeSprite extends THREE.Group {
 		this.sprite = new THREE.Mesh(geometry, material);
 		this.add(this.sprite);
 
-		// Too much coupling?
-		const renderer = ThreeRenderer.getInstance();
-		renderer.camera.onChange(() => {
+		const faceCamera = () => {
 			if (this.billboard) {
 				this.rotation.setFromRotationMatrix(renderer.camera.instance.matrix);
 				this.rotateX(Math.PI * 0.5);
 			}
-		});
+		};
+
+		faceCamera();
+
+		// Too much coupling?
+		const renderer = ThreeRenderer.getInstance();
+		renderer.camera.onChange(() => faceCamera());
 	}
 
 	setScale(sx: number, sy: number) {


### PR DESCRIPTION
This PR fixes the issue of billboard sprites only facing the camera when the camera position/rotation updates, it should also happen on creation.