### PR TITLE
A* Bug Fix and Improvement

### DIFF
--- a/engine/core/TaroBase.js
+++ b/engine/core/TaroBase.js
@@ -390,6 +390,26 @@ Math.distance = function (x1, y1, x2, y2) {
 	return Math.sqrt(((x1 - x2) * (x1 - x2)) + ((y1 - y2) * (y1 - y2)));
 };
 
+/**
+ * Make property non-enumerable.
+ */
+Object.defineProperty(Math, 'clamp', {
+	enumerable: false,
+	writable: true,
+	configurable: true
+});
+
+/**
+ * Clamps the value to within the min and max.
+ * @param value
+ * @param min
+ * @param max
+ * @return {Number}
+ */
+Math.clamp = function (value, min, max) {
+	return Math.min(Math.max(min, value), max);
+};
+
 if (typeof (CanvasRenderingContext2D) !== 'undefined') {
 	// Extend the canvas context to add some helper methods
 	/**

--- a/server/ServerConfig.js
+++ b/server/ServerConfig.js
@@ -40,6 +40,7 @@ var defaultConfig = [
 
 	{ name: 'AbilityComponent', path: '../src/gameClasses/components/unit/AbilityComponent' },
 	{ name: 'AIComponent', path: '../src/gameClasses/components/unit/AIComponent' },
+	{ name: 'AStarPathfindingComponent', path: '../src/gameClasses/components/unit/AStarPathfindingComponent' },
 
 	{ name: 'AttributeComponent', path: '../src/gameClasses/components/entity/AttributeComponent' },
 	{ name: 'VariableComponent', path: '../src/gameClasses/components/entity/VariableComponent' },	

--- a/src/ClientConfig.js
+++ b/src/ClientConfig.js
@@ -52,6 +52,7 @@ var taroClientConfig = {
 		'/gameClasses/components/script/ConditionComponent.js',
 
 		'/gameClasses/components/unit/AIComponent.js',
+		'/gameClasses/components/unit/AStarPathfindingComponent.js',
 		'/gameClasses/components/unit/AbilityComponent.js',
 
 		'/gameClasses/components/entity/AttributeComponent.js',

--- a/src/gameClasses/components/MapComponent.js
+++ b/src/gameClasses/components/MapComponent.js
@@ -15,7 +15,7 @@ var MapComponent = TaroEntity.extend({
 			taro.addComponent(TaroTiledComponent)
 				.tiled.loadJson(data, function (layerArray, layersById) {
 
-					if(layersById.walls) taro.physics.staticsFromMap(layersById.walls);
+					if (layersById.walls) taro.physics.staticsFromMap(layersById.walls);
 
 					self.createRegions();
 				});
@@ -55,7 +55,7 @@ var MapComponent = TaroEntity.extend({
 		}
 	},
 
-	updateWallMapData: function() { // call this after in-game map tile editing
+	updateWallMapData: function () { // call this after in-game map tile editing
 		var self = this;
 
 		let wallLayer = self.data.layers?.find(layerObject => {
@@ -66,7 +66,7 @@ var MapComponent = TaroEntity.extend({
 		this.wallMap?.map(value => value != 0);
 	},
 
-	tileIsWall: function(x, y) {
+	tileIsWall: function (x, y) {
 		return this.wallMap[y * this.data.width + x];
 	},
 

--- a/src/gameClasses/components/MapComponent.js
+++ b/src/gameClasses/components/MapComponent.js
@@ -62,20 +62,12 @@ var MapComponent = TaroEntity.extend({
 			return layerObject.name === 'walls';
 		});
 
-		this.wallMap1d = rfdc()(wallLayer?.data); // cache a copy of wall layer's data
-		this.wallMap2d = [];
-		if (this.wallMap1d) {
-			for (let j = 0; j < this.wallMap1d.length / this.data.width; j++) {
-				this.wallMap2d[j] = [];
-				for (let i = 0; i < this.data.width; i++) {
-					this.wallMap2d[j][i] = (this.wallMap1d[j * this.data.width + i] != 0); // convert all non zero number to 1 (the index does not matter as long as it is not 0)
-				}
-			}
-		}
+		this.wallMap = rfdc()(wallLayer?.data); // cache a copy of wall layer's data
+		this.wallMap?.map(value => value != 0);
 	},
 
 	tileIsWall: function(x, y) {
-		return this.wallMap1d[y * this.data.width + x];
+		return this.wallMap[y * this.data.width + x];
 	},
 
 	getDimensions: function () {

--- a/src/gameClasses/components/MapComponent.js
+++ b/src/gameClasses/components/MapComponent.js
@@ -62,13 +62,20 @@ var MapComponent = TaroEntity.extend({
 			return layerObject.name === 'walls';
 		});
 
-		self.wallMap = rfdc()(wallLayer?.data); // cache a copy of wall layer's data
-
-		for (let i = 0; i < self.wallMap?.length; i++) { // convert all non zero number to 1 (the index does not matter as long as it is not 0)
-			if (self.wallMap[i] != 0) {
-				self.wallMap[i] = 1;
+		this.wallMap1d = rfdc()(wallLayer?.data); // cache a copy of wall layer's data
+		this.wallMap2d = [];
+		if (this.wallMap1d) {
+			for (let j = 0; j < this.wallMap1d.length / this.data.width; j++) {
+				this.wallMap2d[j] = [];
+				for (let i = 0; i < this.data.width; i++) {
+					this.wallMap2d[j][i] = (this.wallMap1d[j * this.data.width + i] != 0); // convert all non zero number to 1 (the index does not matter as long as it is not 0)
+				}
 			}
 		}
+	},
+
+	tileIsWall: function(x, y) {
+		return this.wallMap1d[y * this.data.width + x];
 	},
 
 	getDimensions: function () {

--- a/src/gameClasses/components/MapComponent.js
+++ b/src/gameClasses/components/MapComponent.js
@@ -63,7 +63,7 @@ var MapComponent = TaroEntity.extend({
 		});
 
 		this.wallMap = rfdc()(wallLayer?.data); // cache a copy of wall layer's data
-		this.wallMap?.map(value => value != 0);
+		this.wallMap = this.wallMap?.map(value => value != 0);
 	},
 
 	tileIsWall: function (x, y) {

--- a/src/gameClasses/components/unit/AIComponent.js
+++ b/src/gameClasses/components/unit/AIComponent.js
@@ -9,10 +9,7 @@ var AIComponent = TaroEntity.extend({
 		self.targetPosition = undefined;
 		self.unitsTargetingMe = []; // unit IDs of units attacking/fleeing away from this unit
 		self.debugEnabled = true;
-
-		// A* algorithm variables
-		self.path = []; // AI unit will keep going to highest index until there is no more node to go
-		// everytime when path generate failure, path should set to empty array (this.path = aStarResult.path automatically done for it)
+		self.addComponent(AStarPathfindingComponent);
 
 		// AI settings
 
@@ -179,9 +176,9 @@ var AIComponent = TaroEntity.extend({
 		let distance = 0;
 		const tileWidth = taro.scaleMapDetails.tileWidth;
 		let unit = this._entity;
-		if (this.path.length > 0) { // closestAStarNode exist
-			let a = this.path[this.path.length - 1].x * tileWidth + tileWidth / 2 - unit._translate.x;
-			let b = this.path[this.path.length - 1].y * tileWidth + tileWidth / 2 - unit._translate.y;
+		if (this.aStar.path.length > 0) { // closestAStarNode exist
+			let a = this.aStar.path[this.aStar.path.length - 1].x * tileWidth + tileWidth / 2 - unit._translate.x;
+			let b = this.aStar.path[this.aStar.path.length - 1].y * tileWidth + tileWidth / 2 - unit._translate.y;
 			distance = Math.sqrt(a * a + b * b);
 		}
 		return distance;
@@ -222,7 +219,7 @@ var AIComponent = TaroEntity.extend({
 		this.targetPosition = undefined;
 		this.currentAction = 'idle';
 		this.nextMoveAt = taro._currentTime + 2000 + Math.floor(Math.random() * 2000);
-		this.path = []; // clear the A* path
+		this.aStar.path = []; // clear the A* path
 	},
 
 	fleeFromUnit: function (unit) {
@@ -254,14 +251,14 @@ var AIComponent = TaroEntity.extend({
 			this.previousPosition = { x: this._entity._translate.x, y: this._entity._translate.y };
 		}
 		if (this.pathFindingMethod == 'a*') {
-			let aStarResult = this.getAStarPath(unit._translate.x, unit._translate.y);
-			this.path = aStarResult.path;
+			let aStarResult = this.aStar.getAStarPath(unit._translate.x, unit._translate.y);
+			this.aStar.path = aStarResult.path;
 			if (aStarResult.ok) {
-				if (this.path.length > 0) {
-					this.setTargetPosition(this.path[this.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.path[this.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
+				if (this.aStar.path.length > 0) {
+					this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.aStar.path[this.aStar.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
 				}
 			} else {
-				this.onAStarFailedTrigger();
+				this.aStar.onAStarFailedTrigger();
 				return;
 			}
 		}
@@ -282,16 +279,16 @@ var AIComponent = TaroEntity.extend({
 				this.setTargetPosition(x, y);
 				break;
 			case 'a*':
-				let aStarResult = this.getAStarPath(x, y);
-				this.path = aStarResult.path;
+				let aStarResult = this.aStar.getAStarPath(x, y);
+				this.aStar.path = aStarResult.path;
 				if (aStarResult.ok) {
-					if (this.path.length > 0) {
-						this.setTargetPosition(this.path[this.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.path[this.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
+					if (this.aStar.path.length > 0) {
+						this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.aStar.path[this.aStar.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
 					} else {
 						return; // already reached, dont move
 					}
 				} else {
-					this.onAStarFailedTrigger();
+					this.aStar.onAStarFailedTrigger();
 					return; // dont move if path failed to generate
 				}
 				break;
@@ -299,254 +296,6 @@ var AIComponent = TaroEntity.extend({
 		this.currentAction = 'move';
 		this._entity.startMoving();
 		this.targetUnitId = undefined;
-	},
-
-	/*
-	* @param x
-	* @param y
-	* @return .path = {Array}, .ok = {bool}
-	* Use .path to get return array with x and y coordinates of the path (Start node exclusive) 
-	* if the unit already at the target location, .path return empty array
-	* 
-	* Use .ok to check if path correctly generated 
-	* .ok return true if .path is found or the unit already at the target location
-	* .ok return false if the target location is inside a wall, not reachable
-	* if there is no wall between the start position and the end position, it will return the end position in .path, and return tru in .ok
-	*/
-	getAStarPath: function (x, y) {
-		let returnValue = { path: [], ok: false };
-		let unit = this._entity;
-
-		const mapData = taro.map.data; // cache the map data for rapid use
-		const tileWidth = taro.scaleMapDetails.tileWidth;
-
-		let unitTilePosition = {x: Math.floor(unit._translate.x / tileWidth), y: Math.floor(unit._translate.y / tileWidth)};
-		unitTilePosition.x = Math.min(Math.max(0, unitTilePosition.x), mapData.width - 1); // confine with map boundary
-		unitTilePosition.y = Math.min(Math.max(0, unitTilePosition.y), mapData.height - 1);
-		let targetTilePosition = {x: Math.floor(x / tileWidth), y: Math.floor(y / tileWidth)};
-		targetTilePosition.x = Math.min(Math.max(0, targetTilePosition.x), mapData.width - 1); // confine with map boundary
-		targetTilePosition.y = Math.min(Math.max(0, targetTilePosition.y), mapData.height - 1);
-		
-		if (!this.aStarIsPositionBlocked(x, y)) { // if there is no blocked, directly set the target to the end position
-			returnValue.path.push(rfdc()(targetTilePosition));
-			returnValue.ok = true;
-			return returnValue;
-		}
-
-		const wallMap = taro.map.wallMap; // wall layer cached
-		let openList = []; // store grid nodes that is under evaluation
-		let closeList = []; // store grid nodes that finished evaluation
-		let tempPath = []; // store path to return (smaller index: closer to target, larger index: closer to start)
-		if (wallMap[targetTilePosition.x + targetTilePosition.y * mapData.width] == 1) { // teminate if the target position is wall
-			return returnValue;
-		}
-		openList.push(rfdc()({current: unitTilePosition, parent: {x: -1, y: -1}, totalHeuristic: 0})); // push start node to open List
-
-		// for dropping nodes that overlap with unit body at that new position
-		const unitTileWidthShift = Math.max(0, Math.floor((unit.getBounds().width + tileWidth) / 2 / tileWidth));
-		const unitTileHeightShift = Math.max(0, Math.floor((unit.getBounds().height + tileWidth) / 2 / tileWidth));
-		const averageTileShift = Math.sqrt(unitTileWidthShift * unitTileWidthShift + unitTileHeightShift * unitTileHeightShift);
-
-		while (openList.length > 0) {
-			let minNode = rfdc()(openList[0]); // initialize for iteration
-			let minNodeIndex = 0;
-			for (let i = 1; i < openList.length; i++) {
-				if (openList[i].totalHeuristic < minNode.totalHeuristic) { // only update the minNode if the totalHeuristic is smaller
-					minNodeIndex = i;
-					minNode = rfdc()(openList[i]);
-				}
-			}
-			openList.splice(minNodeIndex, 1); // remove node with smallest distance from openList and add it to close list
-			closeList.push(rfdc()(minNode));
-			if (minNode.current.x == targetTilePosition.x && minNode.current.y == targetTilePosition.y) { // break when the goal is found, push it to tempPath for return
-				tempPath.push(rfdc()(targetTilePosition));
-				break;
-			}
-			for (let i = 0; i < 4; i++) {
-				let newPosition = rfdc()(minNode.current);
-				switch (i) {
-					case 0: // right
-						newPosition.x += 1;
-						if (newPosition.x >= mapData.width) {
-							continue;
-						}
-						break;
-					case 1: // left
-						newPosition.x -= 1;
-						if (newPosition.x < 0) {
-							continue;
-						}
-						break;
-					case 2: // top
-						newPosition.y -= 1;
-						if (newPosition.y < 0) {
-							continue;
-						}
-						break;
-					case 3: // bottom
-						newPosition.y += 1;
-						if (newPosition.y >= mapData.height) {
-							continue;
-						}
-						break;
-				}
-								
-				if (wallMap[newPosition.x + newPosition.y * mapData.width] != 0) continue;// node inside wall, discard				
-				// if new position is not goal, prune it if wall overlaps
-				let shouldPrune = false;
-				for (let i = 1; i <= averageTileShift; i++) {
-					// check 8 direction of average tile shift to see will unit overlap with wall at that node					
-					let cornersHaveWallCurrent = (
-						wallMap[minNode.current.x + i + minNode.current.y * mapData.width] != 0 || wallMap[minNode.current.x - i + minNode.current.y * mapData.width] != 0 ||
-						wallMap[minNode.current.x + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + (minNode.current.y - i) * mapData.width] != 0
-					);
-					let sidesHaveWallCurrent = (
-						wallMap[minNode.current.x + i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x - i + (minNode.current.y - i) * mapData.width] != 0 ||
-						wallMap[minNode.current.x - i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + i + (minNode.current.y - i) * mapData.width]
-					);
-					let cornersHaveWallNew = (
-						wallMap[newPosition.x + i + newPosition.y * mapData.width] != 0 || wallMap[newPosition.x - i + newPosition.y * mapData.width] != 0 ||
-						wallMap[newPosition.x + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + (newPosition.y - i) * mapData.width] != 0
-					);
-					let sidesHaveWallNew = (
-						wallMap[newPosition.x + i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x - i + (newPosition.y - i) * mapData.width] != 0 ||
-						wallMap[newPosition.x - i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + i + (newPosition.y - i) * mapData.width]
-					);
-
-					// Idea: avoid hitting outer corners of wall(dodge by going outer), and allow unit to walk next to walls
-					shouldPrune = (cornersHaveWallNew || sidesHaveWallNew) && (cornersHaveWallCurrent || sidesHaveWallCurrent) && !(cornersHaveWallNew && sidesHaveWallNew && cornersHaveWallCurrent && sidesHaveWallCurrent);
-					if (shouldPrune) break;
-				}
-				if (shouldPrune) continue;
-
-				if (!isNaN(parseInt(this.maxTravelDistance))) {
-					// new Position is way too far from current position (> maxTravelDistance * 5 of unit, total diameter: 10 maxTravelDistance), hence A Star skip this possible node
-					let distanceFromUnitToTarget = Math.sqrt((unit._translate.x - newPosition.x) * (unit._translate.x - newPosition.x) + (unit._translate.y - newPosition.y) * (unit._translate.y - newPosition.y));
-					if (distanceFromUnitToTarget > this.maxTravelDistance * 5) {
-						continue;
-					}
-				}
-
-				// valid node, continue operation!!!
-
-				// 10 to 1 A* heuristic for node with distance that closer to the goal
-				let heuristic = 10;
-				let nodeFound = false; // initialize nodeFound for looping (checking the existance of a node)
-				// cached distance values for calculating the euclidean distance
-				let a = newPosition.x - targetTilePosition.x;
-				let b = newPosition.y - targetTilePosition.y;
-				let c = minNode.current.x - targetTilePosition.x;
-				let d = minNode.current.y - targetTilePosition.y;
-				// In case the euclidean distance to targetTilePosition from the newPosition is smaller than the minNodePosition, reduce the heuristic value (so it tend to choose this node)
-				if (Math.sqrt(a * a + b * b) < Math.sqrt(c * c + d * d)) {
-					heuristic = 1;
-				}
-				for (let k = 0; k < 3; k++) {
-					if (!nodeFound) { // Idea: In open list already ? Update it : In close list already ? Neglect, already reviewed : put it inside openList for evaluation 
-						switch (k) {
-							case 0: // first check if the node exist in open list (if true, update it)
-								for (let j = 0; j < openList.length; j++)
-								{
-									if (newPosition.x == openList[j].current.x && newPosition.y == openList[j].current.y) {
-										if (minNode.totalHeuristic + heuristic < openList[j].totalHeuristic) {
-											openList[j] = rfdc()({current: newPosition, parent: minNode.current, totalHeuristic: minNode.totalHeuristic + heuristic});
-										}
-										nodeFound = true;
-										break;
-									}
-								}
-								break;
-							case 1: // then check if the node exist in the close list (if true, neglect)
-								for (let j = 0; j < closeList.length; j++)
-								{
-									if (newPosition.x == closeList[j].current.x && newPosition.y == closeList[j].current.y) {
-										nodeFound = true;
-										break;
-									}
-								}
-								break;
-							case 2: // finally push it to open list if it does not exist
-								openList.push(rfdc()({current: newPosition, parent: minNode.current, totalHeuristic: minNode.totalHeuristic + heuristic}));
-								break;
-						}
-					} else break;
-				}
-			}
-		}
-		if (tempPath.length == 0) { // goal is unreachable
-			return returnValue;
-		} else {
-			while (tempPath[tempPath.length - 1].x != unitTilePosition.x || tempPath[tempPath.length - 1].y != unitTilePosition.y) { // retrieve the path
-				for (let i = 0; i < closeList.length; i++) {
-					if (tempPath[tempPath.length - 1].x == closeList[i].current.x && tempPath[tempPath.length - 1].y == closeList[i].current.y) {
-						tempPath.push(rfdc()(closeList[i].parent)); // keep pushing the parent node of the node, until it reach the start node from goal node
-						break;
-					}
-				}
-			}
-			tempPath.pop(); // omit start tile, no need to step on it again as we are on it already
-			returnValue.path = tempPath;
-			returnValue.ok = true;
-			return returnValue;
-		}
-	},
-
-	onAStarFailedTrigger: function () {
-		let triggerParam = { unitId: this._entity.id() };
-		taro.script.trigger('unitAStarPathFindingFailed', triggerParam);
-		this._entity.script.trigger('entityAStarPathFindingFailed', triggerParam);
-	},
-
-	aStarIsPositionBlocked: function (targetX, targetY) {
-		let unit = this._entity;
-		const tileWidth = taro.scaleMapDetails.tileWidth;
-		const xTune = [0, -1, 1, -1, 1];
-		const yTune = [0, -1, -1, 1, 1];
-		// center, top-left, top-right, bottom-left, bottom-right
-		const unitWidth = unit.getBounds().width;
-		const unitHeight = unit.getBounds().height;
-		const maxBodySizeShift = Math.sqrt(unitWidth / 2 * unitWidth / 2 + unitHeight / 2 * unitHeight / 2);
-		for (let i = 0; i < 5; i++) {
-			taro.raycaster.raycastLine(
-				{ x: (unit._translate.x + maxBodySizeShift * xTune[i]) / taro.physics._scaleRatio, y: (unit._translate.y + maxBodySizeShift * yTune[i]) / taro.physics._scaleRatio },
-				{ x: (targetX + tileWidth / 2 * Math.sqrt(2) * xTune[i]) / taro.physics._scaleRatio, y: (targetY + tileWidth / 2 * Math.sqrt(2) * yTune[i]) / taro.physics._scaleRatio },
-			)
-			for (let i = 0; i < taro.game.entitiesCollidingWithLastRaycast.length; i++) {
-				if (taro.game.entitiesCollidingWithLastRaycast[i]._category && taro.game.entitiesCollidingWithLastRaycast[i]._category == 'wall') {
-					return true;
-				}
-			}
-		}
-		return false;
-	},
-
-	aStarPathIsBlocked: function() {
-		const mapData = taro.map.data;
-		const wallMap = taro.map.wallMap;
-		let result = false;
-
-		for (let i = 0; i < this.path.length; i++) {
-			if (wallMap[this.path[i].x + this.path[i].y * mapData.width] != 0) {
-				result = true;
-				break;
-			}
-		}
-
-		return result;
-	},
-
-	aStarTargetIsCloser: function (unit, targetUnit) {
-		const tileWidth = taro.scaleMapDetails.tileWidth;
-
-		let a = targetUnit._translate.x - unit._translate.x;
-		let b = targetUnit._translate.y - unit._translate.y;
-		let distanceToTarget = Math.sqrt(a * a + b * b);
-		
-		let c = this.path[0].x * tileWidth + tileWidth / 2 - unit._translate.x;
-		let d = this.path[0].y * tileWidth + tileWidth / 2 - unit._translate.y;
-		let distanceToEndPath = Math.sqrt(c * c + d * d);
-
-		return distanceToTarget < distanceToEndPath;
 	},
 
 	setTargetUnit: function (unit) {
@@ -628,21 +377,21 @@ var AIComponent = TaroEntity.extend({
 						break;
 					case 'a*':
 						if (this.getDistanceToClosestAStarNode() < tileWidth / 2) { // reduced chances of shaky move
-							this.path.pop(); // after moved to the closest A* node, pop the array and let ai move to next A* node
+							this.aStar.path.pop(); // after moved to the closest A* node, pop the array and let ai move to next A* node
 						}
-						if (this.path.length > 0) { // Move to the highest index of path saved (closest node to start node)
-							if (!this.aStarPathIsBlocked()) { // only keep going if the path is still non blocked
-								this.setTargetPosition(this.path[this.path.length - 1].x * tileWidth + tileWidth / 2, this.path[this.path.length - 1].y * tileWidth + tileWidth / 2);
+						if (this.aStar.path.length > 0) { // Move to the highest index of path saved (closest node to start node)
+							if (!this.aStar.aStarPathIsBlocked()) { // only keep going if the path is still non blocked
+								this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * tileWidth + tileWidth / 2, this.aStar.path[this.aStar.path.length - 1].y * tileWidth + tileWidth / 2);
 							} else { 
-								let aStarResult = this.getAStarPath(this.path[0].x, this.path[0].y); // recalculate whole path once the next move is blocked
-								this.path = aStarResult.path;
+								let aStarResult = this.aStar.getAStarPath(this.aStar.path[0].x, this.aStar.path[0].y); // recalculate whole path once the next move is blocked
+								this.aStar.path = aStarResult.path;
 								if (aStarResult.ok) {
-									if (this.path.length > 0) {
-										this.setTargetPosition(this.path[this.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.path[this.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
+									if (this.aStar.path.length > 0) {
+										this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.aStar.path[this.aStar.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
 									}
 								} else {
 									self.goIdle();
-									this.onAStarFailedTrigger();
+									this.aStar.onAStarFailedTrigger();
 								}
 							}
 						} else {
@@ -675,15 +424,15 @@ var AIComponent = TaroEntity.extend({
 							unit.ability.stopUsingItem();
 							unit.startMoving();
 							if (this.pathFindingMethod == 'a*') {
-								let aStarResult = this.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate the moving path to chase
-								this.path = aStarResult.path;
+								let aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate the moving path to chase
+								this.aStar.path = aStarResult.path;
 								if (aStarResult.ok) {
-									if (this.path.length > 0) {
-										this.setTargetPosition(this.path[this.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.path[this.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
+									if (this.aStar.path.length > 0) {
+										this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.aStar.path[this.aStar.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
 									}
 								} else {
 									self.moveToTargetPosition(self.previousPosition.x, self.previousPosition.y);
-									this.onAStarFailedTrigger();
+									this.aStar.onAStarFailedTrigger();
 								}
 							}
 							if (unit.sensor) {
@@ -691,31 +440,31 @@ var AIComponent = TaroEntity.extend({
 							}
 						} else {
 							if (this.pathFindingMethod == 'a*') {
-								if (this.path.length == 0) { // A* path is updated once in attackUnit
-									let aStarResult = this.getAStarPath(targetUnit._translate.x, targetUnit._translate.y);
-									this.path = aStarResult.path; // try to create a new path if the path is empty (Arrived / old path outdated)
+								if (this.aStar.path.length == 0) { // A* path is updated once in attackUnit
+									let aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y);
+									this.aStar.path = aStarResult.path; // try to create a new path if the path is empty (Arrived / old path outdated)
 									if (!aStarResult.ok) {
 										self.moveToTargetPosition(self.previousPosition.x, self.previousPosition.y);
-										this.onAStarFailedTrigger();
+										this.aStar.onAStarFailedTrigger();
 										break;
 									}
 								} else if (this.getDistanceToClosestAStarNode() < tileWidth / 2) { // Euclidean distance is smaller than half of the tile
-									this.path.pop();
+									this.aStar.path.pop();
 								}
 								// After the above decision, choose whether directly move to targetUnit or according to path
-								if (this.path.length > 0) { // select next node to go
-									if (!this.aStarPathIsBlocked() && !this.aStarTargetIsCloser(unit, targetUnit)) { // keep going if the path is still non blocked OR target is actually closer than end node
-										this.setTargetPosition(this.path[this.path.length - 1].x * tileWidth + tileWidth / 2, this.path[this.path.length - 1].y * tileWidth + tileWidth / 2);
+								if (this.aStar.path.length > 0) { // select next node to go
+									if (!this.aStar.aStarPathIsBlocked() && !this.aStar.aStarTargetIsCloser(unit, targetUnit)) { // keep going if the path is still non blocked OR target is actually closer than end node
+										this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * tileWidth + tileWidth / 2, this.aStar.path[this.aStar.path.length - 1].y * tileWidth + tileWidth / 2);
 									} else { 
-										let aStarResult = this.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate whole path once the next move is blocked
-										this.path = aStarResult.path;
+										let aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate whole path once the next move is blocked
+										this.aStar.path = aStarResult.path;
 										if (aStarResult.ok) {
-											if (this.path.length > 0) {
-												this.setTargetPosition(this.path[this.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.path[this.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
+											if (this.aStar.path.length > 0) {
+												this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * taro.map.data.tilewidth + taro.map.data.tilewidth / 2, this.aStar.path[this.aStar.path.length - 1].y * taro.map.data.tilewidth + taro.map.data.tilewidth / 2);
 											}
 										} else {
 											self.moveToTargetPosition(self.previousPosition.x, self.previousPosition.y);
-											this.onAStarFailedTrigger();
+											this.aStar.onAStarFailedTrigger();
 										}
 									}
 								} else {

--- a/src/gameClasses/components/unit/AIComponent.js
+++ b/src/gameClasses/components/unit/AIComponent.js
@@ -19,7 +19,7 @@ var AIComponent = TaroEntity.extend({
 
 			if (unit._stats.ai.sensorRadius > 0 && unit.sensor == undefined) {
 				unit.sensor = new Sensor(unit, unit._stats.ai.sensorRadius);
-		   	}
+			}
 
 			unit._stats.aiEnabled = unit._stats.ai.enabled;
 			if (unit._stats.aiEnabled) {
@@ -28,12 +28,12 @@ var AIComponent = TaroEntity.extend({
 		}
 	},
 
-	enable: function() {
+	enable: function () {
 		var self = this;
 		var unit = self._entity;
 		unit._stats.aiEnabled = true;
 		if (taro.isServer) {
-			unit.streamUpdateData([{aiEnabled: true }]);
+			unit.streamUpdateData([{ aiEnabled: true }]);
 		}
 
 		self.pathFindingMethod = unit._stats.ai.pathFindingMethod; // options: simple/a*
@@ -52,12 +52,12 @@ var AIComponent = TaroEntity.extend({
 		// }
 	},
 
-	disable: function() {
+	disable: function () {
 		var unit = this._entity;
 		unit._stats.aiEnabled = false;
 
 		if (taro.isServer) {
-			unit.streamUpdateData([{aiEnabled: false }]);
+			unit.streamUpdateData([{ aiEnabled: false }]);
 		}
 
 		if (unit.sensor) {
@@ -231,7 +231,7 @@ var AIComponent = TaroEntity.extend({
 				break;
 			case 'a*':
 				this.aStar.setTargetPosition(
-					this._entity._translate.x - (unit._translate.x - this._entity._translate.x), 
+					this._entity._translate.x - (unit._translate.x - this._entity._translate.x),
 					this._entity._translate.y - (unit._translate.y - this._entity._translate.y)
 				);
 				break;
@@ -322,7 +322,7 @@ var AIComponent = TaroEntity.extend({
 			return;
 
 		const tileWidth = taro.scaleMapDetails.tileWidth; // both pathfinding method need it to check
-		
+
 		var targetUnit = this.getTargetUnit();
 
 		// update unit's direction toward its target
@@ -362,10 +362,10 @@ var AIComponent = TaroEntity.extend({
 						if (this.aStar.path.length > 0) { // Move to the highest index of path saved (closest node to start node)
 							if (!this.aStar.aStarPathIsBlocked()) { // only keep going if the path is still non blocked
 								this.setTargetPosition(
-									(this.aStar.path[this.aStar.path.length - 1].x + 0.5) * tileWidth, 
+									(this.aStar.path[this.aStar.path.length - 1].x + 0.5) * tileWidth,
 									(this.aStar.path[this.aStar.path.length - 1].y + 0.5) * tileWidth
 								);
-							} else { 
+							} else {
 								this.aStar.setTargetPosition(this.aStar.path[0].x, this.aStar.path[0].y); // recalculate whole path once the next move is blocked
 							}
 						} else {
@@ -381,7 +381,7 @@ var AIComponent = TaroEntity.extend({
 					if (!isNaN(parseInt(self.maxTravelDistance)) && distanceTravelled > self.maxTravelDistance) {
 						// we've chased far enough. stop fighting and return to where i was before
 						self.moveToTargetPosition(self.previousPosition.x, self.previousPosition.y);
-					} else if (!isNaN(parseInt(self.letGoDistance)) && this.getDistanceToTarget() > self.letGoDistance) { 
+					} else if (!isNaN(parseInt(self.letGoDistance)) && this.getDistanceToTarget() > self.letGoDistance) {
 						// if the target is far away from the unit, stop the chase
 						self.goIdle();
 					} else {
@@ -407,16 +407,16 @@ var AIComponent = TaroEntity.extend({
 								if (this.getDistanceToClosestAStarNode() < tileWidth / 2) { // reduced chances of shaky move
 									this.aStar.path.pop(); // after moved to the closest A* node, pop the array and let ai move to next A* node
 								}
-								if (this.aStar.path.length > 0 && !this.aStar.aStarPathIsBlocked() && !this.aStar.aStarTargetUnitMoved()) { 
+								if (this.aStar.path.length > 0 && !this.aStar.aStarPathIsBlocked() && !this.aStar.aStarTargetUnitMoved()) {
 									// Move to the highest index of path saved (closest node to start node) 
 									// only keep follow the old path if the path is still non blocked AND targetUnit is not closer than end node of the path
 									this.setTargetPosition(
-										(this.aStar.path[this.aStar.path.length - 1].x + 0.5) * tileWidth, 
+										(this.aStar.path[this.aStar.path.length - 1].x + 0.5) * tileWidth,
 										(this.aStar.path[this.aStar.path.length - 1].y + 0.5) * tileWidth
 									);
-								} else { 
+								} else {
 									// recalculate whole path
-									this.aStar.setTargetPosition(targetUnit._translate.x, targetUnit._translate.y); 
+									this.aStar.setTargetPosition(targetUnit._translate.x, targetUnit._translate.y);
 								}
 							}
 						}
@@ -436,7 +436,7 @@ var AIComponent = TaroEntity.extend({
 				if (unit.angleToTarget && this.pathFindingMethod == "simple") unit.angleToTarget += Math.PI;
 				if (targetUnit) {
 					var distanceTravelled = Math.distance(
-						self.previousPosition.x, self.previousPosition.y, 
+						self.previousPosition.x, self.previousPosition.y,
 						targetUnit._translate.x, targetUnit._translate.y
 					);
 					if (this.pathFindingMethod == "a*") {
@@ -445,14 +445,14 @@ var AIComponent = TaroEntity.extend({
 						}
 						if (this.aStar.path.length > 0 && !this.aStar.aStarPathIsBlocked() && !this.aStar.aStarTargetUnitMoved()) { // Move to the highest index of path saved (closest node to start node)
 							this.setTargetPosition( // only keep going if the path is still non blocked
-								(this.aStar.path[this.aStar.path.length - 1].x + 0.5) * tileWidth, 
+								(this.aStar.path[this.aStar.path.length - 1].x + 0.5) * tileWidth,
 								(this.aStar.path[this.aStar.path.length - 1].y + 0.5) * tileWidth
 							);
 						} else {
 							this.aStar.setTargetPosition(
-								this._entity._translate.x - (targetUnit._translate.x - this._entity._translate.x), 
+								this._entity._translate.x - (targetUnit._translate.x - this._entity._translate.x),
 								this._entity._translate.y - (targetUnit._translate.y - this._entity._translate.y)
-							); 
+							);
 						}
 					}
 					// we've ran far enough OR we've been running for long enough (5-10s) let's stop running

--- a/src/gameClasses/components/unit/AIComponent.js
+++ b/src/gameClasses/components/unit/AIComponent.js
@@ -355,7 +355,7 @@ var AIComponent = TaroEntity.extend({
 								);
 							} else {
 								this.aStar.setTargetPosition( // recalculate whole path once the next move is blocked
-									(this.aStar.path[0].x + 0.5) * tileWidth, 
+									(this.aStar.path[0].x + 0.5) * tileWidth,
 									(this.aStar.path[0].y + 0.5) * tileWidth
 								);
 							}

--- a/src/gameClasses/components/unit/AIComponent.js
+++ b/src/gameClasses/components/unit/AIComponent.js
@@ -251,7 +251,7 @@ var AIComponent = TaroEntity.extend({
 			this.previousPosition = { x: this._entity._translate.x, y: this._entity._translate.y };
 		}
 		if (this.pathFindingMethod == 'a*') {
-			let aStarResult = this.aStar.getAStarPath(unit._translate.x, unit._translate.y);
+			const aStarResult = this.aStar.getAStarPath(unit._translate.x, unit._translate.y);
 			this.aStar.path = aStarResult.path;
 			if (aStarResult.ok) {
 				if (this.aStar.path.length > 0) {
@@ -279,7 +279,7 @@ var AIComponent = TaroEntity.extend({
 				this.setTargetPosition(x, y);
 				break;
 			case 'a*':
-				let aStarResult = this.aStar.getAStarPath(x, y);
+				const aStarResult = this.aStar.getAStarPath(x, y);
 				this.aStar.path = aStarResult.path;
 				if (aStarResult.ok) {
 					if (this.aStar.path.length > 0) {
@@ -383,7 +383,7 @@ var AIComponent = TaroEntity.extend({
 							if (!this.aStar.aStarPathIsBlocked()) { // only keep going if the path is still non blocked
 								this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * tileWidth + tileWidth / 2, this.aStar.path[this.aStar.path.length - 1].y * tileWidth + tileWidth / 2);
 							} else { 
-								let aStarResult = this.aStar.getAStarPath(this.aStar.path[0].x, this.aStar.path[0].y); // recalculate whole path once the next move is blocked
+								const aStarResult = this.aStar.getAStarPath(this.aStar.path[0].x, this.aStar.path[0].y); // recalculate whole path once the next move is blocked
 								this.aStar.path = aStarResult.path;
 								if (aStarResult.ok) {
 									if (this.aStar.path.length > 0) {
@@ -424,7 +424,7 @@ var AIComponent = TaroEntity.extend({
 							unit.ability.stopUsingItem();
 							unit.startMoving();
 							if (this.pathFindingMethod == 'a*') {
-								let aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate the moving path to chase
+								const aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate the moving path to chase
 								this.aStar.path = aStarResult.path;
 								if (aStarResult.ok) {
 									if (this.aStar.path.length > 0) {
@@ -441,7 +441,7 @@ var AIComponent = TaroEntity.extend({
 						} else {
 							if (this.pathFindingMethod == 'a*') {
 								if (this.aStar.path.length == 0) { // A* path is updated once in attackUnit
-									let aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y);
+									const aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y);
 									this.aStar.path = aStarResult.path; // try to create a new path if the path is empty (Arrived / old path outdated)
 									if (!aStarResult.ok) {
 										self.moveToTargetPosition(self.previousPosition.x, self.previousPosition.y);
@@ -456,7 +456,7 @@ var AIComponent = TaroEntity.extend({
 									if (!this.aStar.aStarPathIsBlocked() && !this.aStar.aStarTargetIsCloser(unit, targetUnit)) { // keep going if the path is still non blocked OR target is actually closer than end node
 										this.setTargetPosition(this.aStar.path[this.aStar.path.length - 1].x * tileWidth + tileWidth / 2, this.aStar.path[this.aStar.path.length - 1].y * tileWidth + tileWidth / 2);
 									} else { 
-										let aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate whole path once the next move is blocked
+										const aStarResult = this.aStar.getAStarPath(targetUnit._translate.x, targetUnit._translate.y); // recalculate whole path once the next move is blocked
 										this.aStar.path = aStarResult.path;
 										if (aStarResult.ok) {
 											if (this.aStar.path.length > 0) {

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -36,7 +36,7 @@ class AStarPathfindingComponent extends TaroEntity {
 		targetTilePosition.y = Math.min(Math.max(0, targetTilePosition.y), mapData.height - 1);
 		
 		if (!this.aStarIsPositionBlocked(x, y)) { // if there is no blocked, directly set the target to the end position
-			returnValue.path.push(rfdc()(targetTilePosition));
+			returnValue.path.push({...targetTilePosition});
 			returnValue.ok = true;
 			return returnValue;
 		}
@@ -48,7 +48,7 @@ class AStarPathfindingComponent extends TaroEntity {
 		if (wallMap[targetTilePosition.x + targetTilePosition.y * mapData.width] == 1) { // teminate if the target position is wall
 			return returnValue;
 		}
-		openList.push(rfdc()({current: unitTilePosition, parent: {x: -1, y: -1}, totalHeuristic: 0})); // push start node to open List
+		openList.push({current: {...unitTilePosition}, parent: {x: -1, y: -1}, totalHeuristic: 0}); // push start node to open List
 
 		// for dropping nodes that overlap with unit body at that new position
 		const unitTileWidthShift = Math.max(0, Math.floor((unit.getBounds().width + tileWidth) / 2 / tileWidth));
@@ -56,22 +56,22 @@ class AStarPathfindingComponent extends TaroEntity {
 		const averageTileShift = Math.sqrt(unitTileWidthShift * unitTileWidthShift + unitTileHeightShift * unitTileHeightShift);
 
 		while (openList.length > 0) {
-			let minNode = rfdc()(openList[0]); // initialize for iteration
+			let minNode = {...openList[0]}; // initialize for iteration
 			let minNodeIndex = 0;
 			for (let i = 1; i < openList.length; i++) {
 				if (openList[i].totalHeuristic < minNode.totalHeuristic) { // only update the minNode if the totalHeuristic is smaller
 					minNodeIndex = i;
-					minNode = rfdc()(openList[i]);
+					minNode = {...openList[i]};
 				}
 			}
 			openList.splice(minNodeIndex, 1); // remove node with smallest distance from openList and add it to close list
-			closeList.push(rfdc()(minNode));
+			closeList.push({...minNode});
 			if (minNode.current.x == targetTilePosition.x && minNode.current.y == targetTilePosition.y) { // break when the goal is found, push it to tempPath for return
-				tempPath.push(rfdc()(targetTilePosition));
+				tempPath.push({...targetTilePosition});
 				break;
 			}
 			for (let i = 0; i < 4; i++) {
-				let newPosition = rfdc()(minNode.current);
+				let newPosition = {...minNode.current};
 				switch (i) {
 					case 0: // right
 						newPosition.x += 1;
@@ -157,7 +157,7 @@ class AStarPathfindingComponent extends TaroEntity {
 								{
 									if (newPosition.x == openList[j].current.x && newPosition.y == openList[j].current.y) {
 										if (minNode.totalHeuristic + heuristic < openList[j].totalHeuristic) {
-											openList[j] = rfdc()({current: newPosition, parent: minNode.current, totalHeuristic: minNode.totalHeuristic + heuristic});
+											openList[j] = {current: {...newPosition}, parent: {...minNode.current}, totalHeuristic: minNode.totalHeuristic + heuristic};
 										}
 										nodeFound = true;
 										break;
@@ -174,7 +174,7 @@ class AStarPathfindingComponent extends TaroEntity {
 								}
 								break;
 							case 2: // finally push it to open list if it does not exist
-								openList.push(rfdc()({current: newPosition, parent: minNode.current, totalHeuristic: minNode.totalHeuristic + heuristic}));
+								openList.push({current: {...newPosition}, parent: {...minNode.current}, totalHeuristic: minNode.totalHeuristic + heuristic});
 								break;
 						}
 					} else break;
@@ -187,7 +187,7 @@ class AStarPathfindingComponent extends TaroEntity {
 			while (tempPath[tempPath.length - 1].x != unitTilePosition.x || tempPath[tempPath.length - 1].y != unitTilePosition.y) { // retrieve the path
 				for (let i = 0; i < closeList.length; i++) {
 					if (tempPath[tempPath.length - 1].x == closeList[i].current.x && tempPath[tempPath.length - 1].y == closeList[i].current.y) {
-						tempPath.push(rfdc()(closeList[i].parent)); // keep pushing the parent node of the node, until it reach the start node from goal node
+						tempPath.push({...closeList[i].parent}); // keep pushing the parent node of the node, until it reach the start node from goal node
 						break;
 					}
 				}

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -1,0 +1,263 @@
+class AStarPathfindingComponent extends TaroEntity {
+	classId = 'AStarPathfindingComponent';
+	componentId = 'aStar';
+    constructor(unit) {
+        super();
+		this._entity = unit._entity;
+
+		// A* algorithm variables
+		this.path = []; // AI unit will keep going to highest index until there is no more node to go
+		// everytime when path generate failure, path should set to empty array (this.path = aStarResult.path automatically done for it)
+    }
+	/*
+    * @param x
+	* @param y
+	* @return .path = {Array}, .ok = {bool}
+	* Use .path to get return array with x and y coordinates of the path (Start node exclusive) 
+	* if the unit already at the target location, .path return empty array
+	* 
+	* Use .ok to check if path correctly generated 
+	* .ok return true if .path is found or the unit already at the target location
+	* .ok return false if the target location is inside a wall, not reachable
+	* if there is no wall between the start position and the end position, it will return the end position in .path, and return tru in .ok
+	*/
+	getAStarPath(x, y) {
+		let returnValue = { path: [], ok: false };
+		let unit = this._entity;
+
+		const mapData = taro.map.data; // cache the map data for rapid use
+		const tileWidth = taro.scaleMapDetails.tileWidth;
+
+		let unitTilePosition = {x: Math.floor(unit._translate.x / tileWidth), y: Math.floor(unit._translate.y / tileWidth)};
+		unitTilePosition.x = Math.min(Math.max(0, unitTilePosition.x), mapData.width - 1); // confine with map boundary
+		unitTilePosition.y = Math.min(Math.max(0, unitTilePosition.y), mapData.height - 1);
+		let targetTilePosition = {x: Math.floor(x / tileWidth), y: Math.floor(y / tileWidth)};
+		targetTilePosition.x = Math.min(Math.max(0, targetTilePosition.x), mapData.width - 1); // confine with map boundary
+		targetTilePosition.y = Math.min(Math.max(0, targetTilePosition.y), mapData.height - 1);
+		
+		if (!this.aStarIsPositionBlocked(x, y)) { // if there is no blocked, directly set the target to the end position
+			returnValue.path.push(rfdc()(targetTilePosition));
+			returnValue.ok = true;
+			return returnValue;
+		}
+
+		const wallMap = taro.map.wallMap; // wall layer cached
+		let openList = []; // store grid nodes that is under evaluation
+		let closeList = []; // store grid nodes that finished evaluation
+		let tempPath = []; // store path to return (smaller index: closer to target, larger index: closer to start)
+		if (wallMap[targetTilePosition.x + targetTilePosition.y * mapData.width] == 1) { // teminate if the target position is wall
+			return returnValue;
+		}
+		openList.push(rfdc()({current: unitTilePosition, parent: {x: -1, y: -1}, totalHeuristic: 0})); // push start node to open List
+
+		// for dropping nodes that overlap with unit body at that new position
+		const unitTileWidthShift = Math.max(0, Math.floor((unit.getBounds().width + tileWidth) / 2 / tileWidth));
+		const unitTileHeightShift = Math.max(0, Math.floor((unit.getBounds().height + tileWidth) / 2 / tileWidth));
+		const averageTileShift = Math.sqrt(unitTileWidthShift * unitTileWidthShift + unitTileHeightShift * unitTileHeightShift);
+
+		while (openList.length > 0) {
+			let minNode = rfdc()(openList[0]); // initialize for iteration
+			let minNodeIndex = 0;
+			for (let i = 1; i < openList.length; i++) {
+				if (openList[i].totalHeuristic < minNode.totalHeuristic) { // only update the minNode if the totalHeuristic is smaller
+					minNodeIndex = i;
+					minNode = rfdc()(openList[i]);
+				}
+			}
+			openList.splice(minNodeIndex, 1); // remove node with smallest distance from openList and add it to close list
+			closeList.push(rfdc()(minNode));
+			if (minNode.current.x == targetTilePosition.x && minNode.current.y == targetTilePosition.y) { // break when the goal is found, push it to tempPath for return
+				tempPath.push(rfdc()(targetTilePosition));
+				break;
+			}
+			for (let i = 0; i < 4; i++) {
+				let newPosition = rfdc()(minNode.current);
+				switch (i) {
+					case 0: // right
+						newPosition.x += 1;
+						if (newPosition.x >= mapData.width) {
+							continue;
+						}
+						break;
+					case 1: // left
+						newPosition.x -= 1;
+						if (newPosition.x < 0) {
+							continue;
+						}
+						break;
+					case 2: // top
+						newPosition.y -= 1;
+						if (newPosition.y < 0) {
+							continue;
+						}
+						break;
+					case 3: // bottom
+						newPosition.y += 1;
+						if (newPosition.y >= mapData.height) {
+							continue;
+						}
+						break;
+				}
+								
+				if (wallMap[newPosition.x + newPosition.y * mapData.width] != 0) continue;// node inside wall, discard				
+				// if new position is not goal, prune it if wall overlaps
+				let shouldPrune = false;
+				for (let i = 1; i <= averageTileShift; i++) {
+					// check 8 direction of average tile shift to see will unit overlap with wall at that node					
+					let cornersHaveWallCurrent = (
+						wallMap[minNode.current.x + i + minNode.current.y * mapData.width] != 0 || wallMap[minNode.current.x - i + minNode.current.y * mapData.width] != 0 ||
+						wallMap[minNode.current.x + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + (minNode.current.y - i) * mapData.width] != 0
+					);
+					let sidesHaveWallCurrent = (
+						wallMap[minNode.current.x + i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x - i + (minNode.current.y - i) * mapData.width] != 0 ||
+						wallMap[minNode.current.x - i + (minNode.current.y + i) * mapData.width] != 0 || wallMap[minNode.current.x + i + (minNode.current.y - i) * mapData.width]
+					);
+					let cornersHaveWallNew = (
+						wallMap[newPosition.x + i + newPosition.y * mapData.width] != 0 || wallMap[newPosition.x - i + newPosition.y * mapData.width] != 0 ||
+						wallMap[newPosition.x + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + (newPosition.y - i) * mapData.width] != 0
+					);
+					let sidesHaveWallNew = (
+						wallMap[newPosition.x + i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x - i + (newPosition.y - i) * mapData.width] != 0 ||
+						wallMap[newPosition.x - i + (newPosition.y + i) * mapData.width] != 0 || wallMap[newPosition.x + i + (newPosition.y - i) * mapData.width]
+					);
+
+					// Idea: avoid hitting outer corners of wall(dodge by going outer), and allow unit to walk next to walls
+					shouldPrune = (cornersHaveWallNew || sidesHaveWallNew) && (cornersHaveWallCurrent || sidesHaveWallCurrent) && !(cornersHaveWallNew && sidesHaveWallNew && cornersHaveWallCurrent && sidesHaveWallCurrent);
+					if (shouldPrune) break;
+				}
+				if (shouldPrune) continue;
+
+				if (!isNaN(parseInt(this.maxTravelDistance))) {
+					// new Position is way too far from current position (> maxTravelDistance * 5 of unit, total diameter: 10 maxTravelDistance), hence A Star skip this possible node
+					let distanceFromUnitToTarget = Math.sqrt((unit._translate.x - newPosition.x) * (unit._translate.x - newPosition.x) + (unit._translate.y - newPosition.y) * (unit._translate.y - newPosition.y));
+					if (distanceFromUnitToTarget > this.maxTravelDistance * 5) {
+						continue;
+					}
+				}
+
+				// valid node, continue operation!!!
+
+				// 10 to 1 A* heuristic for node with distance that closer to the goal
+				let heuristic = 10;
+				let nodeFound = false; // initialize nodeFound for looping (checking the existance of a node)
+				// cached distance values for calculating the euclidean distance
+				let a = newPosition.x - targetTilePosition.x;
+				let b = newPosition.y - targetTilePosition.y;
+				let c = minNode.current.x - targetTilePosition.x;
+				let d = minNode.current.y - targetTilePosition.y;
+				// In case the euclidean distance to targetTilePosition from the newPosition is smaller than the minNodePosition, reduce the heuristic value (so it tend to choose this node)
+				if (Math.sqrt(a * a + b * b) < Math.sqrt(c * c + d * d)) {
+					heuristic = 1;
+				}
+				for (let k = 0; k < 3; k++) {
+					if (!nodeFound) { // Idea: In open list already ? Update it : In close list already ? Neglect, already reviewed : put it inside openList for evaluation 
+						switch (k) {
+							case 0: // first check if the node exist in open list (if true, update it)
+								for (let j = 0; j < openList.length; j++)
+								{
+									if (newPosition.x == openList[j].current.x && newPosition.y == openList[j].current.y) {
+										if (minNode.totalHeuristic + heuristic < openList[j].totalHeuristic) {
+											openList[j] = rfdc()({current: newPosition, parent: minNode.current, totalHeuristic: minNode.totalHeuristic + heuristic});
+										}
+										nodeFound = true;
+										break;
+									}
+								}
+								break;
+							case 1: // then check if the node exist in the close list (if true, neglect)
+								for (let j = 0; j < closeList.length; j++)
+								{
+									if (newPosition.x == closeList[j].current.x && newPosition.y == closeList[j].current.y) {
+										nodeFound = true;
+										break;
+									}
+								}
+								break;
+							case 2: // finally push it to open list if it does not exist
+								openList.push(rfdc()({current: newPosition, parent: minNode.current, totalHeuristic: minNode.totalHeuristic + heuristic}));
+								break;
+						}
+					} else break;
+				}
+			}
+		}
+		if (tempPath.length == 0) { // goal is unreachable
+			return returnValue;
+		} else {
+			while (tempPath[tempPath.length - 1].x != unitTilePosition.x || tempPath[tempPath.length - 1].y != unitTilePosition.y) { // retrieve the path
+				for (let i = 0; i < closeList.length; i++) {
+					if (tempPath[tempPath.length - 1].x == closeList[i].current.x && tempPath[tempPath.length - 1].y == closeList[i].current.y) {
+						tempPath.push(rfdc()(closeList[i].parent)); // keep pushing the parent node of the node, until it reach the start node from goal node
+						break;
+					}
+				}
+			}
+			tempPath.pop(); // omit start tile, no need to step on it again as we are on it already
+			returnValue.path = tempPath;
+			returnValue.ok = true;
+			return returnValue;
+		}
+	}
+	
+	onAStarFailedTrigger() {
+		let triggerParam = { unitId: this._entity.id() };
+		taro.script.trigger('unitAStarPathFindingFailed', triggerParam);
+		this._entity.script.trigger('entityAStarPathFindingFailed', triggerParam);
+	}
+
+	aStarIsPositionBlocked(targetX, targetY) {
+		let unit = this._entity;
+		const tileWidth = taro.scaleMapDetails.tileWidth;
+		const xTune = [0, -1, 1, -1, 1];
+		const yTune = [0, -1, -1, 1, 1];
+		// center, top-left, top-right, bottom-left, bottom-right
+		const unitWidth = unit.getBounds().width;
+		const unitHeight = unit.getBounds().height;
+		const maxBodySizeShift = Math.sqrt(unitWidth / 2 * unitWidth / 2 + unitHeight / 2 * unitHeight / 2);
+		for (let i = 0; i < 5; i++) {
+			taro.raycaster.raycastLine(
+				{ x: (unit._translate.x + maxBodySizeShift * xTune[i]) / taro.physics._scaleRatio, y: (unit._translate.y + maxBodySizeShift * yTune[i]) / taro.physics._scaleRatio },
+				{ x: (targetX + tileWidth / 2 * Math.sqrt(2) * xTune[i]) / taro.physics._scaleRatio, y: (targetY + tileWidth / 2 * Math.sqrt(2) * yTune[i]) / taro.physics._scaleRatio },
+			)
+			for (let i = 0; i < taro.game.entitiesCollidingWithLastRaycast.length; i++) {
+				if (taro.game.entitiesCollidingWithLastRaycast[i]._category && taro.game.entitiesCollidingWithLastRaycast[i]._category == 'wall') {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	aStarPathIsBlocked() {
+		const mapData = taro.map.data;
+		const wallMap = taro.map.wallMap;
+		let result = false;
+
+		for (let i = 0; i < this.path.length; i++) {
+			if (wallMap[this.path[i].x + this.path[i].y * mapData.width] != 0) {
+				result = true;
+				break;
+			}
+		}
+
+		return result;
+	}
+
+	aStarTargetIsCloser(unit, targetUnit) {
+		const tileWidth = taro.scaleMapDetails.tileWidth;
+
+		let a = targetUnit._translate.x - unit._translate.x;
+		let b = targetUnit._translate.y - unit._translate.y;
+		let distanceToTarget = Math.sqrt(a * a + b * b);
+		
+		let c = this.path[0].x * tileWidth + tileWidth / 2 - unit._translate.x;
+		let d = this.path[0].y * tileWidth + tileWidth / 2 - unit._translate.y;
+		let distanceToEndPath = Math.sqrt(c * c + d * d);
+
+		return distanceToTarget < distanceToEndPath;
+	}
+}
+
+if (typeof (module) !== 'undefined' && typeof (module.exports) !== 'undefined') {
+	module.exports = AStarPathfindingComponent;
+}

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -36,7 +36,7 @@ class AStarPathfindingComponent extends TaroEntity {
 		const targetTilePosition = { x: Math.floor(x / tileWidth), y: Math.floor(y / tileWidth) };
 		targetTilePosition.x = Math.clamp(targetTilePosition.x, 0, mapData.width - 1); // confine with map boundary
 		targetTilePosition.y = Math.clamp(targetTilePosition.y, 0, mapData.height - 1);
-		
+
 		let returnValue = { path: [{ ...targetTilePosition }], ok: false };
 
 		if (!this.aStarIsPositionBlocked(x, y)) { // if there is no blocked, directly set the target to the end position

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -194,6 +194,7 @@ class AStarPathfindingComponent extends TaroEntity {
 			returnValue.path = tempPath;
 			returnValue.ok = true;
 			console.timeEnd(`Time For Get A* Path ${this._entity._stats.cellSheet.url} ${uniqueId}`);
+			console.log(closeList.length);
 			return returnValue;
 		}
 	}
@@ -247,11 +248,28 @@ class AStarPathfindingComponent extends TaroEntity {
 			unit._translate.x, unit._translate.y
 		);
 		const distanceToEndPath = Math.distance(
-			this.path[0].x * tileWidth + tileWidth / 2, this.path[0].y * tileWidth + tileWidth / 2,
+			(this.path[0].x + 0.5) * tileWidth, (this.path[0].y + 0.5) * tileWidth,
 			unit._translate.x, unit._translate.y
 		);
 
 		return distanceToTarget < distanceToEndPath;
+	}
+
+	setTargetPosition(x, y) {
+		const aStarResult = this.getAStarPath(x, y);
+		this.path = aStarResult.path;
+		if (aStarResult.ok) {
+			if (this.path.length > 0) {
+				const tileWidth = taro.scaleMapDetails.tileWidth;
+				this._entity.ai.setTargetPosition(
+					(this.path[this.path.length - 1].x + 0.5) * tileWidth, 
+					(this.path[this.path.length - 1].y + 0.5) * tileWidth
+				);
+			}
+		} else {
+			this.onAStarFailedTrigger();
+		}
+		return aStarResult.ok;
 	}
 }
 


### PR DESCRIPTION
## What's New
### A\*
- Put A\* logic into another file [AStarPathfindingComponent.js](https://github.com/moddio/moddio2/compare/master...PineappleBrain:AStarImprovement?expand=1#diff-e7fc01e8fbd4a9288377ac2cfcfdd7fef507f60b78a011fd0d424982be63b4db)
- Convert all deep clone into shadow clone
  - shadow clone is sufficient `rfdc()(obj)` -> `{...obj}`
- `wallMap` is bool now (no need to check for != 0)
- Added `tileIsWall()` check in [MapComponent.js](https://github.com/moddio/moddio2/compare/master...PineappleBrain:AStarImprovement?expand=1#diff-2891046bb618fc92a22573e2ddff7350f2fe44122b673ef0cef0c61290ada819)
- Added `Math.clamp(val, min, max)` in [TaroBase.js](https://github.com/moddio/moddio2/compare/master...PineappleBrain:AStarImprovement?expand=1#diff-5958cc28f44a6b218b4d3b58d601293b552c0d2c92afc5b4ad3aa9097a45061b)
- New function `aStar.setTargetPosition(x, y)` to group duplicate codes
- change `val * tileWidth + tileWidth / 2 ` to `(val + 0.5) * tileWidth` (1 division less)
- Fix issue that ai with state fight have some delay chasing its target
- Simplify some logic, simplify redundant and ambiguous codes
- Removed `aStarTargetIsCloser`, replaced by `aStarTargetUnitMoved`
- Flee is smarter now
- **Now A\* will fallback to simple-pathfinding-like movement if a path is not found (not reachable / in wall) instead of go idle**
  - **it can still be overriden using trigger by the creator**
- And some miscellaneous
### AI
- Fix bug that flee immediately stop if `maxTravelDistance` is not set
- Use `Math.distance(x1, x2, y1, y1)` from TaroBase.js