### PR TITLE
Add mathTrunc

### DIFF
--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -1279,6 +1279,13 @@ var ParameterComponent = TaroEntity.extend({
 						}
 						break;
 
+					case 'mathTrunc':
+						var value = self.getValue(text.value, vars);
+						if (!isNaN(value)) {
+							returnValue = Math.trunc(value);
+						}
+						break;
+
 					case 'log10':
 						var value = self.getValue(text.value, vars);
 


### PR DESCRIPTION
### Rationale for implementing this:
Useful for rounding to the nearest integer towards 0, and unlike floor, ceiling, or round, it will go closer to 0 rather than always down, up, or to the closest integer.

### Referenced Issue:
[Github issue of the requested feature](https://github.com/moddio/moddio2/issues/835)

### Demo game JSON:
I don't think this is needed really since it is so simple