### PR TITLE
Change standalone server port from 80 to 8080

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "An HTML5 multiplayer game engine, enabling anyone to make games at modd.io.",
 	"main": "server/taro.js",
 	"scripts": {
-		"server": "cross-env ENV=standalone JWT_SECRET_KEY='change-this' node server/taro.js -g ./src",
+		"server": "cross-env PORT=8080 ENV=standalone JWT_SECRET_KEY='change-this' node server/taro.js -g ./src",
 		"server:prod": "node server/taro.js -g ./src",
 		"server:cc": "cross-env ENV=standalone LOAD_CC=true JWT_SECRET_KEY='change-this' node --inspect server/taro.js -g ./src",
 		"tsc": "tsc",

--- a/server/server.js
+++ b/server/server.js
@@ -224,7 +224,7 @@ var Server = TaroClass.extend({
 
 	startWebServer: function () {
 		const app = express();
-		const port = 80;
+		const port = process.env.PORT || 80;
 
 		app.use(bodyParser.urlencoded({ extended: false }));
 		// parse application/json
@@ -353,7 +353,6 @@ var Server = TaroClass.extend({
 		}
 
 		this.socket = {};
-		var port = process.env.PORT || 2001;
 
 		this.duplicateIpCount = {};
 


### PR DESCRIPTION
On first impression npm run server
EADDRINUSE: address already in use :::80

This change allows the script to take a PORT environment variable.
I also removed a line in startgame() that was doing something similar that but not working. The variable was unused.

### Rationale for implementing this:
The server was almost working straight from git pull apart from these lines;
The port default 80 seem to be blocked on most system. On my linux mint there is no server on port 80 but it will still not allow a server there.

### Referenced Issue:
None, I fixed it to make my first build
