### PR TITLE
Integrate side tilesets

### DIFF
--- a/ts/types/GameComponent.d.ts
+++ b/ts/types/GameComponent.d.ts
@@ -94,6 +94,7 @@ interface MapData {
 		tilecount: number;
 		tileheight: number;
 		tilewidth: number;
+		type?: 'top' | 'side';
 	}[];
 	layers: {
 		y: number;


### PR DESCRIPTION
Allow a different tileset to be set for the sides of voxels in the 3D renderer.

