### PR TITLE
Add xPosToTile and yPosToTile

### DIFF
--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -1079,6 +1079,22 @@ var ParameterComponent = TaroEntity.extend({
 
 						break;
 
+					case 'xPosToTile':
+						var tileWidth = 64 || taro.game.data.map.tilewidth;
+						var xPos = self.getValue(text.xPos, vars);
+
+						returnValue = Math.floor(xPos / tileWidth);
+
+						break;
+
+					case 'yPosToTile':
+						var tileHeight = 64 || taro.game.data.map.tileheight;
+						var yPos = self.getValue(text.yPos, vars);
+
+						returnValue = Math.floor(yPos / tileHeight);
+
+						break;
+
 					case 'getMapJson':
 						returnValue = JSON.stringify(taro.map.data);
 


### PR DESCRIPTION
### Rationale for implementing this:
Helpful for preventing repetition for converting positions to a tile, whether for trying to get the tile ID of a position, or centering a unit on their tile, etc

### Referenced Issue:
[Github issue of the requested feature](https://github.com/moddio/moddio2/issues/836)

### Demo game JSON:
Haven't done yet, will update when I do