### PR TITLE
Add instant camera movement capabilities to the 3D renderer

### DIFF
--- a/ts/src/renderer/three/ThreeCamera.ts
+++ b/ts/src/renderer/three/ThreeCamera.ts
@@ -249,8 +249,14 @@ class ThreeCamera {
 		this.setDistance(this.originalDistance / ratio);
 	}
 
-	startFollow(target: THREE.Object3D) {
+	startFollow(target: THREE.Object3D, moveInstant = true) {
 		this.target = target;
+
+		if (moveInstant) {
+			const targetWorldPos = new THREE.Vector3();
+			target.getWorldPosition(targetWorldPos);
+			this.setPosition(targetWorldPos.x, targetWorldPos.y, targetWorldPos.z);
+		}
 	}
 
 	stopFollow() {

--- a/ts/src/renderer/three/ThreeCamera.ts
+++ b/ts/src/renderer/three/ThreeCamera.ts
@@ -222,7 +222,7 @@ class ThreeCamera {
 		if (this.target) {
 			const targetWorldPos = new THREE.Vector3();
 			this.target.getWorldPosition(targetWorldPos);
-			this.setPosition(targetWorldPos);
+			this.setPosition(targetWorldPos.x, targetWorldPos.y, targetWorldPos.z, true);
 		}
 
 		this.controls.update();
@@ -291,10 +291,19 @@ class ThreeCamera {
 		}
 	}
 
-	setPosition(target: THREE.Vector3) {
+	setPosition(x: number, y: number, z: number, lerp = false) {
 		const oldTarget = this.controls.target.clone();
-		const diff = target.clone().sub(oldTarget);
-		const t = (taro?.game?.data?.settings?.camera?.trackingDelay || 3) / taro.fps();
+		const diff = new THREE.Vector3(x, y, z).sub(oldTarget);
+		const t = lerp ? (taro?.game?.data?.settings?.camera?.trackingDelay || 3) / taro.fps() : 1;
+		this.controls.target.lerp(this.controls.target.clone().add(this.offset).add(diff), t);
+		this.orthographicCamera.position.lerp(this.orthographicCamera.position.clone().add(this.offset).add(diff), t);
+		this.perspectiveCamera.position.lerp(this.perspectiveCamera.position.clone().add(this.offset).add(diff), t);
+	}
+
+	setPosition2D(x: number, z: number, lerp = false) {
+		const oldTarget = this.controls.target.clone();
+		const diff = new THREE.Vector3(x, oldTarget.y, z).sub(oldTarget);
+		const t = lerp ? (taro?.game?.data?.settings?.camera?.trackingDelay || 3) / taro.fps() : 1;
 		this.controls.target.lerp(this.controls.target.clone().add(this.offset).add(diff), t);
 		this.orthographicCamera.position.lerp(this.orthographicCamera.position.clone().add(this.offset).add(diff), t);
 		this.perspectiveCamera.position.lerp(this.perspectiveCamera.position.clone().add(this.offset).add(diff), t);

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -460,6 +460,15 @@ class ThreeRenderer {
 
 		taro.client.on('camera-pitch', (deg: number) => this.camera.setElevationAngle(deg));
 
+		taro.client.on('camera-instant-move', (x: number, y: number) => {
+			if (!taro.developerMode.active || taro.developerMode.activeTab === 'play') {
+				this.camera.setPosition2D(
+					this.scene.position.x + Utils.pixelToWorld(x),
+					this.scene.position.z + Utils.pixelToWorld(y)
+				);
+			}
+		});
+
 		this.renderer.domElement.addEventListener('mousemove', (evt: MouseEvent) => {
 			this.pointer.set((evt.clientX / window.innerWidth) * 2 - 1, -(evt.clientY / window.innerHeight) * 2 + 1);
 		});

--- a/ts/src/renderer/three/ThreeRenderer.ts
+++ b/ts/src/renderer/three/ThreeRenderer.ts
@@ -460,6 +460,16 @@ class ThreeRenderer {
 
 		taro.client.on('camera-pitch', (deg: number) => this.camera.setElevationAngle(deg));
 
+		taro.client.on('camera-position', (x: number, y: number) => {
+			if (!taro.developerMode.active || taro.developerMode.activeTab === 'play') {
+				this.camera.setPosition2D(
+					this.scene.position.x + Utils.pixelToWorld(x),
+					this.scene.position.z + Utils.pixelToWorld(y),
+					true
+				);
+			}
+		});
+
 		taro.client.on('camera-instant-move', (x: number, y: number) => {
 			if (!taro.developerMode.active || taro.developerMode.activeTab === 'play') {
 				this.camera.setPosition2D(


### PR DESCRIPTION
This PR:

- Instantly move the camera when it's starting to follow an entity
- Allow for the camera to be instantly moved
- Allow for the camera to be smoothly moved