### PR TITLE
Add "regionContainsPosition"

### DIFF
--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -2707,6 +2707,21 @@ var ParameterComponent = TaroEntity.extend({
 					return regionA.intersects(regionB);
 				}
 			},
+
+			'regionContainsPosition': function (text, vars) {
+				var region = self.getValue(text.region, vars);
+				var position = self.getValue(text.position, vars);
+				if (!region || !position) {
+					return false;
+				}
+				if (region._category == 'region') {
+					region = region.getBounds();
+				}
+				if (region) {
+					region = new TaroRect(region.x, region.y, region.width, region.height);
+					return region.xyInside(position.x, position.y);
+				}
+			},
 			/* variable */
 
 			'getVariable': function (text, vars) {


### PR DESCRIPTION
It simply checks if the given position is contained within the given region and returns true or false, something that previously required making a 0x0 region with the x and y each set to the x and y of the position and then comparing that to your region (quite annoying and long without variables, which aren't always an easy option).

### Rationale for implementing this:
Allows checking entities against regions without chance of overlap (for example, if you are making a 4 corners minigame, you wouldn't want a player to be considered in two of the regions at once; checking the players center position against the region instead of their hitbox against the region would prevent that). Can also be used for checking things with no size in the first place against regions, like the location where a player clicked against a chest in the world.

### Referenced Issue:
Afaik doesnt exist, if this is needed then I can make one.

### Demo game JSON:
(Doesn't exist yet, will probably finish this eventually)
