### PR TITLE
Fix chat bubble offset in the 3D renderer

### DIFF
--- a/ts/src/renderer/three/Label.ts
+++ b/ts/src/renderer/three/Label.ts
@@ -7,6 +7,7 @@ namespace Renderer {
 			private scaleScalar = 1;
 
 			private size = new THREE.Vector2();
+			private textSize = new THREE.Vector2();
 			private center = new THREE.Vector2(0.5, 0.5);
 
 			constructor(text = 'cccccc', color = 'white', bold = false) {
@@ -66,16 +67,18 @@ namespace Renderer {
 				const textCanvas = document.createElement('canvas');
 				textCanvas.height = 10;
 
-				const padding = 8;
-
 				const ctx = textCanvas.getContext('2d');
 				const font = `${bold ? 'bold' : 'normal'} 16px Verdana`;
-
 				ctx.font = font;
 				const metrics = ctx.measureText(text);
-				const textHeight = metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
-				textCanvas.width = Math.ceil(metrics.width) + padding;
-				textCanvas.height = Math.ceil(textHeight) + padding;
+
+				const textWidth = Math.ceil(metrics.width);
+				const textHeight = Math.ceil(metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent);
+				this.textSize.set(textWidth, textHeight);
+
+				const padding = 8;
+				textCanvas.width = textWidth + padding;
+				textCanvas.height = textHeight + padding;
 				this.size.set(textCanvas.width, textCanvas.height);
 
 				const isStroke = taro.game.data.settings.addStrokeToNameAndAttributes;
@@ -86,6 +89,7 @@ namespace Renderer {
 					ctx.lineJoin = 'miter';
 					ctx.miterLimit = 3;
 					ctx.strokeText(text, padding / 2, textHeight + padding / 2);
+					this.textSize.addScalar(2);
 				}
 
 				ctx.fillStyle = color;
@@ -115,6 +119,10 @@ namespace Renderer {
 				);
 
 				return sprite;
+			}
+
+			getTextSizeInPixels() {
+				return { width: this.textSize.x * this.scaleScalar, height: this.textSize.y * this.scaleScalar };
 			}
 		}
 	}

--- a/ts/src/renderer/three/Unit.ts
+++ b/ts/src/renderer/three/Unit.ts
@@ -32,8 +32,9 @@ namespace Renderer {
 				} else {
 					this.chat = new ChatBubble(text);
 					this.chat.setScale(this.guiScale);
+					const textHeight = this.label.getTextSizeInPixels().height;
 					this.chat.setOffset(
-						new THREE.Vector2(0, this.getSizeInPixels().height * 0.5 + this.chat.getSizeInPixels().height * 4),
+						new THREE.Vector2(0, this.getSizeInPixels().height * 0.5 + textHeight * 4),
 						new THREE.Vector2(0.5, 0)
 					);
 					this.add(this.chat);


### PR DESCRIPTION
This PR moves the chat bubble closer to the unit to better match the offset used in the Phaser renderer.
