### PR TITLE
use halfWidth/Height when using dists' box creation method

### DIFF
--- a/engine/components/physics/box2d/Box2dComponent.js
+++ b/engine/components/physics/box2d/Box2dComponent.js
@@ -177,7 +177,6 @@ var PhysicsComponent = TaroEventingClass.extend({
 	 */
 	createBody: function (entity, body, isLossTolerant) {
 		this.totalBodiesCreated++;
-
 		return dists[this.engine].createBody(this, entity, body, isLossTolerant);
 	},
 

--- a/engine/components/physics/box2d/TaroEntityPhysics.js
+++ b/engine/components/physics/box2d/TaroEntityPhysics.js
@@ -82,10 +82,10 @@ var TaroEntityPhysics = TaroEntity.extend({
 				shapeData = {};
 			}
 			if (sizeX) {
-				shapeData.width = sizeX;
+				shapeData.halfWidth = sizeX / 2;
 			}
 			if (sizeY) {
-				shapeData.height = sizeY;
+				shapeData.halfHeight = sizeY / 2;
 			}
 			if (offsetX) {
 				shapeData.x = offsetX;

--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -143,7 +143,7 @@ var TaroEntity = TaroObject.extend({
 
 	// update item's body & texture based on stateId given
 	setState: function (stateId, defaultData) {
-		// console.log("setState", stateId, defaultData)
+		console.log("setState", stateId, defaultData);
 		var self = this;
 
 		// if invalid stateId is given, set state to default state
@@ -160,6 +160,7 @@ var TaroEntity = TaroObject.extend({
 
 			*/
 			self._stats.currentBody = self._stats.bodies[newState.body];
+			console.log(self._stats.currentBody);
 		}
 
 		if (taro.isServer) {

--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -143,7 +143,6 @@ var TaroEntity = TaroObject.extend({
 
 	// update item's body & texture based on stateId given
 	setState: function (stateId, defaultData) {
-		console.log("setState", stateId, defaultData);
 		var self = this;
 
 		// if invalid stateId is given, set state to default state
@@ -160,7 +159,6 @@ var TaroEntity = TaroObject.extend({
 
 			*/
 			self._stats.currentBody = self._stats.bodies[newState.body];
-			console.log(self._stats.currentBody);
 		}
 
 		if (taro.isServer) {

--- a/ts/engine/components/physics/box2d/distsWrapper/box2dtsWrapper.ts
+++ b/ts/engine/components/physics/box2d/distsWrapper/box2dtsWrapper.ts
@@ -172,8 +172,10 @@ const box2dtsWrapper: PhysicsDistProps = {
 		var tempShape;
 		var tempFilterData;
 		var i;
-		var finalX; var finalY;
-		var finalWidth; var finalHeight;
+		var finalX;
+		var finalY;
+		var finalHWidth;
+		var finalHHeight;
 
 		// Process body definition and create a box2d body for it
 		switch (body.type) {
@@ -265,7 +267,7 @@ const box2dtsWrapper: PhysicsDistProps = {
 												}
 												*/
 
-											if (fixtureDef.shape.data && typeof (fixtureDef.shape.data.radius) !== 'undefined') {
+											if (fixtureDef.shape.data && typeof fixtureDef.shape.data.radius !== 'undefined') {
 												// tempShape.SetRadius(fixtureDef.shape.data.radius / self._scaleRatio);
 												var p = new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio);
 												var r = fixtureDef.shape.data.radius / self._scaleRatio;
@@ -285,15 +287,15 @@ const box2dtsWrapper: PhysicsDistProps = {
 											tempShape = new self.b2PolygonShape();
 
 											if (fixtureDef.shape.data) {
-												finalX = fixtureDef.shape.data.x !== undefined ? fixtureDef.shape.data.x : 0;
-												finalY = fixtureDef.shape.data.y !== undefined ? fixtureDef.shape.data.y : 0;
-												finalWidth = fixtureDef.shape.data.width !== undefined ? fixtureDef.shape.data.width : (entity._bounds2d.x / 2);
-												finalHeight = fixtureDef.shape.data.height !== undefined ? fixtureDef.shape.data.height : (entity._bounds2d.y / 2);
+												finalX = fixtureDef.shape.data.x ?? 0;
+												finalY = fixtureDef.shape.data.y ?? 0;
+												finalHWidth = fixtureDef.shape.data.halfWidth ?? entity._bounds2d.x / 2;
+												finalHHeight = fixtureDef.shape.data.halfHeight ?? entity._bounds2d.y / 2;
 											} else {
 												finalX = 0;
 												finalY = 0;
-												finalWidth = (entity._bounds2d.x / 2);
-												finalHeight = (entity._bounds2d.y / 2);
+												finalHWidth = entity._bounds2d.x / 2;
+												finalHHeight = entity._bounds2d.y / 2;
 											}
 
 											// Set the polygon as a box
@@ -309,8 +311,8 @@ const box2dtsWrapper: PhysicsDistProps = {
 											// review:
 
 											tempShape.SetAsBox(
-												(finalWidth / self._scaleRatio),
-												(finalHeight / self._scaleRatio)
+												finalHWidth / self._scaleRatio,
+												finalHHeight / self._scaleRatio
 											);
 											break;
 									}

--- a/ts/engine/components/physics/box2d/distsWrapper/box2dwasmWrapper.ts
+++ b/ts/engine/components/physics/box2d/distsWrapper/box2dwasmWrapper.ts
@@ -290,7 +290,7 @@ const box2dwasmWrapper: PhysicsDistProps = { // added by Moe'Thun for fixing mem
 									switch (fixtureDef.shape.type) {
 										case 'circle':
 											tempShape = self.recordLeak(new self.b2CircleShape());
-											if (fixtureDef.shape.data && typeof (fixtureDef.shape.data.radius) !== 'undefined') {
+											if (fixtureDef.shape.data && typeof fixtureDef.shape.data.radius !== 'undefined') {
 												tempShape.set_m_radius(fixtureDef.shape.data.radius / self._scaleRatio);
 											} else {
 												tempShape.set_m_radius(entity._bounds2d.x / self._scaleRatio / 2);
@@ -311,16 +311,15 @@ const box2dwasmWrapper: PhysicsDistProps = { // added by Moe'Thun for fixing mem
 											if (fixtureDef.shape.data) {
 												finalX = fixtureDef.shape.data.x ?? 0;
 												finalY = fixtureDef.shape.data.y ?? 0;
-												finalHWidth = fixtureDef.shape.data.width ?? entity._bounds2d.x;
-												finalHHeight = fixtureDef.shape.data.height ?? entity._bounds2d.y;
+												finalHWidth = fixtureDef.shape.data.halfWidth ?? entity._bounds2d.x / 2;
+												finalHHeight = fixtureDef.shape.data.halfHeight ?? entity._bounds2d.y / 2;
 											} else {
 												finalX = 0;
 												finalY = 0;
-												finalHWidth = entity._bounds2d.x;
-												finalHHeight = entity._bounds2d.y;
+												finalHWidth = entity._bounds2d.x / 2;
+												finalHHeight = entity._bounds2d.y / 2;
 											}
-											finalHWidth /= 2;
-											finalHHeight /= 2;
+
 											const pos = self.recordLeak(new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio));
 											// Set the polygon as a box
 											(tempShape as Box2D.b2PolygonShape).SetAsBox(

--- a/ts/engine/components/physics/box2d/distsWrapper/box2dwebWrapper.ts
+++ b/ts/engine/components/physics/box2d/distsWrapper/box2dwebWrapper.ts
@@ -148,8 +148,10 @@ const box2dwebWrapper: PhysicsDistProps = {
 		var tempShape;
 		var tempFilterData;
 		var i;
-		var finalX; var finalY;
-		var finalWidth; var finalHeight;
+		var finalX;
+		var finalY;
+		var finalHWidth;
+		var finalHHeight;
 
 		// Process body definition and create a box2d body for it
 		switch (body.type) {
@@ -225,15 +227,15 @@ const box2dwebWrapper: PhysicsDistProps = {
 									switch (fixtureDef.shape.type) {
 										case 'circle':
 											tempShape = new self.b2CircleShape();
-											if (fixtureDef.shape.data && typeof (fixtureDef.shape.data.radius) !== 'undefined') {
+											if (fixtureDef.shape.data && typeof fixtureDef.shape.data.radius !== 'undefined') {
 												tempShape.SetRadius(fixtureDef.shape.data.radius / self._scaleRatio);
 											} else {
-												tempShape.SetRadius((entity._bounds2d.x / self._scaleRatio) / 2);
+												tempShape.SetRadius(entity._bounds2d.x / self._scaleRatio / 2);
 											}
 
 											if (fixtureDef.shape.data) {
-												finalX = fixtureDef.shape.data.x !== undefined ? fixtureDef.shape.data.x : 0;
-												finalY = fixtureDef.shape.data.y !== undefined ? fixtureDef.shape.data.y : 0;
+												finalX = fixtureDef.shape.data.x ?? 0;
+												finalY = fixtureDef.shape.data.y ?? 0;
 
 												tempShape.SetLocalPosition(new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio));
 											}
@@ -248,21 +250,21 @@ const box2dwebWrapper: PhysicsDistProps = {
 											tempShape = new self.b2PolygonShape();
 
 											if (fixtureDef.shape.data) {
-												finalX = fixtureDef.shape.data.x !== undefined ? fixtureDef.shape.data.x : 0;
-												finalY = fixtureDef.shape.data.y !== undefined ? fixtureDef.shape.data.y : 0;
-												finalWidth = fixtureDef.shape.data.width !== undefined ? fixtureDef.shape.data.width : (entity._bounds2d.x / 2);
-												finalHeight = fixtureDef.shape.data.height !== undefined ? fixtureDef.shape.data.height : (entity._bounds2d.y / 2);
+												finalX = fixtureDef.shape.data.x ?? 0;
+												finalY = fixtureDef.shape.data.y ?? 0;
+												finalHWidth = fixtureDef.shape.data.halfWidth ?? entity._bounds2d.x / 2;
+												finalHHeight = fixtureDef.shape.data.halfHeight ?? entity._bounds2d.y / 2;
 											} else {
 												finalX = 0;
 												finalY = 0;
-												finalWidth = (entity._bounds2d.x / 2);
-												finalHeight = (entity._bounds2d.y / 2);
+												finalHWidth = entity._bounds2d.x / 2;
+												finalHHeight = entity._bounds2d.y / 2;
 											}
 
 											// Set the polygon as a box
 											tempShape.SetAsOrientedBox(
-												(finalWidth / self._scaleRatio),
-												(finalHeight / self._scaleRatio),
+												finalHWidth / self._scaleRatio,
+												finalHHeight / self._scaleRatio,
 												new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio),
 												0
 											);

--- a/ts/engine/components/physics/box2d/distsWrapper/planckWrapper.ts
+++ b/ts/engine/components/physics/box2d/distsWrapper/planckWrapper.ts
@@ -80,8 +80,10 @@ const planckWrapper: PhysicsDistProps = {
 		var tempShape;
 		var tempFilterData;
 		var i;
-		var finalX; var finalY;
-		var finalWidth; var finalHeight;
+		var finalX;
+		var finalY;
+		var finalHWidth;
+		var finalHHeight;
 
 		// Add the parameters of the body to the new body instance
 		for (param in body) {
@@ -143,17 +145,17 @@ const planckWrapper: PhysicsDistProps = {
 									switch (fixtureDef.shape.type) {
 										case 'circle':
 											tempShape = new self.b2CircleShape();
-											if (fixtureDef.shape.data && typeof (fixtureDef.shape.data.radius) !== 'undefined') {
-												tempShape.m_radius = (fixtureDef.shape.data.radius / self._scaleRatio);
+											if (fixtureDef.shape.data && typeof fixtureDef.shape.data.radius !== 'undefined') {
+												tempShape.m_radius = fixtureDef.shape.data.radius / self._scaleRatio;
 											} else {
-												tempShape.m_radius = ((entity._bounds2d.x / self._scaleRatio) / 2);
+												tempShape.m_radius = entity._bounds2d.x / self._scaleRatio / 2;
 											}
 
 											if (fixtureDef.shape.data) {
-												finalX = fixtureDef.shape.data.x !== undefined ? fixtureDef.shape.data.x : 0;
-												finalY = fixtureDef.shape.data.y !== undefined ? fixtureDef.shape.data.y : 0;
+												finalX = fixtureDef.shape.data.x ?? 0;
+												finalY = fixtureDef.shape.data.y ?? 0;
 
-												tempShape.m_p = (new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio));
+												tempShape.m_p = new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio);
 											}
 											break;
 
@@ -166,21 +168,21 @@ const planckWrapper: PhysicsDistProps = {
 											tempShape = new self.b2PolygonShape();
 
 											if (fixtureDef.shape.data) {
-												finalX = fixtureDef.shape.data.x !== undefined ? fixtureDef.shape.data.x : 0;
-												finalY = fixtureDef.shape.data.y !== undefined ? fixtureDef.shape.data.y : 0;
-												finalWidth = fixtureDef.shape.data.width !== undefined ? fixtureDef.shape.data.width : (entity._bounds2d.x / 2);
-												finalHeight = fixtureDef.shape.data.height !== undefined ? fixtureDef.shape.data.height : (entity._bounds2d.y / 2);
+												finalX = fixtureDef.shape.data.x ?? 0;
+												finalY = fixtureDef.shape.data.y ?? 0;
+												finalHWidth = fixtureDef.shape.data.halfWidth ?? entity._bounds2d.x / 2;
+												finalHHeight = fixtureDef.shape.data.halfHeight ?? entity._bounds2d.y / 2;
 											} else {
 												finalX = 0;
 												finalY = 0;
-												finalWidth = (entity._bounds2d.x / 2);
-												finalHeight = (entity._bounds2d.y / 2);
+												finalHWidth = entity._bounds2d.x / 2;
+												finalHHeight = entity._bounds2d.y / 2;
 											}
 
 											// Set the polygon as a box
 											tempShape._setAsBox(
-												(finalWidth / self._scaleRatio),
-												(finalHeight / self._scaleRatio),
+												finalHWidth / self._scaleRatio,
+												finalHHeight / self._scaleRatio,
 												new self.b2Vec2(finalX / self._scaleRatio, finalY / self._scaleRatio),
 												0
 											);


### PR DESCRIPTION
Physics dists internally use a box creation method that creates vertices from position and **half** width/height data. Custom physics bodies (rect only) were sending physics component a body def with width/height instead. The result was physics bodies twice the expected size when using custom dimensions.

These changes affect the local variable names within these dist files and modify the body creation process in `TaroEntityPhysics.js` to send **half** values of width and height to the body creation process.