### PR TITLE
Add camera pan and rotate functionality in the 3D map editor

### DIFF
--- a/ts/src/renderer/three/Camera.ts
+++ b/ts/src/renderer/three/Camera.ts
@@ -10,6 +10,8 @@ namespace Renderer {
 			orthographicState: { target: THREE.Vector3; position: THREE.Vector3 };
 			perspectiveState: { target: THREE.Vector3; position: THREE.Vector3; zoom: number };
 
+			isDevelopmentMode = false;
+
 			private orthographicCamera: THREE.OrthographicCamera;
 			private perspectiveCamera: THREE.PerspectiveCamera;
 			private isPerspective = false;
@@ -25,6 +27,8 @@ namespace Renderer {
 			private originalHalfWidth;
 
 			private originalZoom = 1;
+			private elevationAngle = 0;
+			private azimuthAngle = 0;
 
 			constructor(
 				private viewportWidth: number,
@@ -78,7 +82,14 @@ namespace Renderer {
 				this.controls.maxDistance = 1000;
 				this.controls.minZoom = 1 / (1000 / distance);
 				this.controls.maxZoom = 1 / (0.01 / distance);
+				this.controls.screenSpacePanning = false;
 				this.controls.update();
+
+				this.controls.mouseButtons = {
+					LEFT: THREE.MOUSE.PAN,
+					MIDDLE: THREE.MOUSE.DOLLY,
+					RIGHT: THREE.MOUSE.ROTATE,
+				};
 
 				this.controls.addEventListener('change', () => {
 					for (const cb of this.onChangeCbs) {
@@ -144,6 +155,8 @@ namespace Renderer {
 			}
 
 			setElevationAngle(deg: number) {
+				this.elevationAngle = deg;
+
 				const spherical = new THREE.Spherical();
 				spherical.radius = this.controls.getDistance();
 				spherical.theta = this.controls.getAzimuthalAngle();
@@ -164,6 +177,8 @@ namespace Renderer {
 			}
 
 			setAzimuthAngle(deg: number) {
+				this.azimuthAngle = deg;
+
 				const spherical = new THREE.Spherical();
 				spherical.radius = this.controls.getDistance();
 				spherical.phi = this.controls.getPolarAngle();
@@ -230,7 +245,7 @@ namespace Renderer {
 					this.debugInfo.innerHTML += `zoom: ${editorZoom}</br>`;
 				}
 
-				if (this.target) {
+				if (this.target && !this.isDevelopmentMode) {
 					const targetWorldPos = new THREE.Vector3();
 					this.target.getWorldPosition(targetWorldPos);
 					this.setPosition(targetWorldPos.x, targetWorldPos.y, targetWorldPos.z, true);
@@ -339,6 +354,24 @@ namespace Renderer {
 
 			onChange(cb: () => void) {
 				this.onChangeCbs.push(cb);
+			}
+
+			setDevelopmentMode(state: boolean) {
+				this.isDevelopmentMode = state;
+
+				if (this.isDevelopmentMode) {
+					this.controls.enablePan = true;
+					this.controls.enableRotate = true;
+					this.controls.enableZoom = true;
+				} else {
+					this.controls.enablePan = false;
+					this.controls.enableRotate = false;
+					this.controls.enableZoom = false;
+
+					this.setElevationAngle(this.elevationAngle);
+					this.setAzimuthAngle(this.azimuthAngle);
+					this.setZoom(this.originalZoom);
+				}
 			}
 
 			private switchToOrthographicCamera() {

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -1,6 +1,11 @@
 /// <reference types="@types/google.analytics" />
 
 namespace Renderer {
+	export enum Mode {
+		Normal,
+		Development,
+	}
+
 	export namespace Three {
 		export function instance() {
 			return Renderer.instance();
@@ -12,6 +17,7 @@ namespace Renderer {
 			renderer: THREE.WebGLRenderer;
 			camera: Camera;
 			scene: THREE.Scene;
+			mode = Mode.Normal;
 
 			private clock = new THREE.Clock();
 			private pointer = new THREE.Vector2();
@@ -91,6 +97,15 @@ namespace Renderer {
 				};
 
 				this.loadTextures();
+
+				taro.client.on('enterMapTab', () => {
+					this.mode = Mode.Development;
+					this.onDevelopmentMode();
+				});
+				taro.client.on('leaveMapTab', () => {
+					this.mode = Mode.Normal;
+					this.onNormalMode();
+				});
 			}
 
 			static instance() {
@@ -120,6 +135,12 @@ namespace Renderer {
 			getCameraHeight(): number {
 				return window.innerHeight;
 			}
+
+			private onDevelopmentMode() {
+				console.log('Development mode');
+			}
+
+			private onNormalMode() {}
 
 			private loadTextures() {
 				const textureRepository = TextureRepository.instance();

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -99,12 +99,16 @@ namespace Renderer {
 				this.loadTextures();
 
 				taro.client.on('enterMapTab', () => {
-					this.mode = Mode.Development;
-					this.onDevelopmentMode();
+					if (this.mode == Mode.Normal) {
+						this.mode = Mode.Development;
+						this.onDevelopmentMode();
+					}
 				});
 				taro.client.on('leaveMapTab', () => {
-					this.mode = Mode.Normal;
-					this.onNormalMode();
+					if (this.mode == Mode.Development) {
+						this.mode = Mode.Normal;
+						this.onNormalMode();
+					}
 				});
 			}
 
@@ -137,10 +141,12 @@ namespace Renderer {
 			}
 
 			private onDevelopmentMode() {
-				console.log('Development mode');
+				this.camera.setDevelopmentMode(true);
 			}
 
-			private onNormalMode() {}
+			private onNormalMode() {
+				this.camera.setDevelopmentMode(false);
+			}
 
 			private loadTextures() {
 				const textureRepository = TextureRepository.instance();


### PR DESCRIPTION
This PR adds the ability to pan (left mouse button) and rotate (right mouse button) the camera in while the 'Map' tab is active in the 3D renderer.