### PR TITLE
fix: hide everything except the map after changed to map tab

### DIFF
--- a/ts/src/renderer/phaser/scenes/GameScene.ts
+++ b/ts/src/renderer/phaser/scenes/GameScene.ts
@@ -127,7 +127,7 @@ class GameScene extends PhaserScene {
 
 
 		taro.client.on('create-particle', (particle: Particle) => {
-			new PhaserParticle(this, particle);
+			this.renderedEntities.push(new PhaserParticle(this, particle))
 		});
 
 

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -140,12 +140,21 @@ namespace Renderer {
 				return window.innerHeight;
 			}
 
+			setVisible(visible: boolean) {
+				this.particles.visible = visible;
+				this.entityManager.entities.forEach((e) => {
+					e.visible = visible;
+				});
+			}
+
 			private onDevelopmentMode() {
 				this.camera.setDevelopmentMode(true);
+				this.setVisible(false);
 			}
 
 			private onNormalMode() {
 				this.camera.setDevelopmentMode(false);
+				this.setVisible(true);
 			}
 
 			private loadTextures() {


### PR DESCRIPTION
### Rationale for implementing this:
- phaser renderer do not hide the particles in map tab
- threejs do not hide anything in map tab

### Referenced Issue:


### Demo game JSON:
- [three.js] 
[threejs_HidePariclesAfterChangedToMap.txt](https://github.com/moddio/moddio2/files/14696607/threejs_HidePariclesAfterChangedToMap.txt)
- [phaser] 
[HidePariclesAfterChangedToMap_2024321_2156.txt](https://github.com/moddio/moddio2/files/14696608/HidePariclesAfterChangedToMap_2024321_2156.txt)
