### PR TITLE
Fix annoying shop bug

### DIFF
--- a/src/gameClasses/components/InventoryComponent.js
+++ b/src/gameClasses/components/InventoryComponent.js
@@ -219,7 +219,7 @@ var InventoryComponent = TaroEntity.extend({
 						}
 
 						// matching item isn't full, and new item can fit in.
-						if (item._stats.maxQuantity - item._stats.quantity > quantity) {
+						if (item._stats.maxQuantity - item._stats.quantity >= quantity) {
 							return i + 1;
 						} else {
 							if (item._stats.quantity != undefined) {


### PR DESCRIPTION
buying an item with a full inventory except for a stack of items that has exactly enough space to hold the item you are buying will still tell you that your inventory is full (yes I really encountered this and coped so hard I went into f12 and found the bug myself)

### Rationale for implementing this:
bug stupid
