### PR TITLE
fix: dropped bodies which do not have offset will never go back to 0 offset

### DIFF
--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -239,7 +239,6 @@ var TaroEntity = TaroObject.extend({
 		}
 
 		var body = self._stats.currentBody;
-
 		if (body) {
 			if (!body['z-index']) {
 				body['z-index'] = defaultLayer;
@@ -254,8 +253,8 @@ var TaroEntity = TaroObject.extend({
 			self.layer(body['z-index'].layer) // above "floor 2 layer", but under "trees layer"
 				.depth(body['z-index'].depth);
 
-      if (!isNaN(body['z-index'].offset)) {
-				self.zOffset(body['z-index'].offset);
+			if (!isNaN(body['z-index'].offset) || body['z-index'].offset === undefined) {
+				self.zOffset(body['z-index'].offset ?? 0);
 			}
 		}
 	},


### PR DESCRIPTION
### Rationale for implementing this:
- after pick some item up or just select it and then dropped it, it won't be on the ground, but is underground sadly

### Referenced Issue:


### Demo game JSON:
use LAD or any game using threejs renderer
