### PR TITLE
feat: support editMapTile and rejoin game use the latest game map

### DIFF
--- a/ts/src/gameClasses/DeveloperMode.ts
+++ b/ts/src/gameClasses/DeveloperMode.ts
@@ -385,9 +385,9 @@ class DeveloperMode {
 				}
 				case 'edit': {
 					//save tile change to taro.game.data.map and taro.map.data
-					const nowValue = serverData as Omit<TileData<'edit'>['edit'], 'layer'> & { layer: number };
+					const nowValue = serverData as TileData<'edit'>['edit'];
 					nowValue.selectedTiles.map((v, idx) => {
-						this.putTiles(nowValue.x, nowValue.y, v, nowValue.size, nowValue.shape, nowValue.layer);
+						this.putTiles(nowValue.x, nowValue.y, v, nowValue.size, nowValue.shape, nowValue.layer[idx]);
 					});
 					break;
 				}
@@ -437,8 +437,9 @@ class DeveloperMode {
 					if (sample[x] && sample[x][y] !== undefined && this.pointerInsideMap(x + tileX, y + tileY, map)) {
 						let index = sample[x][y];
 						if (index === -1) index = 0;
-						map.layers[layer].data[x + tileX + (y + tileY) * width] = index;
-						taro.map.data.layers[layer].data[x + tileX + (y + tileY) * width] = index;
+						let indices = x + tileX + (y + tileY) * width;
+						map.layers[layer].data[indices] = index;
+						taro.map.data.layers[layer].data[indices] = index;
 					}
 				}
 			}

--- a/ts/types/TaroEngine.d.ts
+++ b/ts/types/TaroEngine.d.ts
@@ -87,5 +87,13 @@ declare class TaroEngine extends TaroClass {
 
 	mapEditorUI: any;
 
-	getTilesetFromType: ({ tilesets, type, onlyIndex }: { tilesets: Array<any>, type: 'top' | 'side', onlyIndex?: boolean }) => any;
+	getTilesetFromType: ({
+		tilesets,
+		type,
+		onlyIndex,
+	}: {
+		tilesets: Array<any>;
+		type: 'top' | 'side';
+		onlyIndex?: boolean;
+	}) => any;
 }


### PR DESCRIPTION
### Rationale for implementing this:
- support editMapTile
- rejoin game use the latest game map

### Referenced Issue:


### Demo game JSON:
[EditMapTile.txt](https://github.com/moddio/moddio2/files/14948857/EditMapTile.txt)
(some item effects don't match its description, now, most of them can only edit the 0 layer)