### PR TITLE
fix: forget to add the missing 0.5 to the x and z

### DIFF
--- a/ts/src/renderer/three/Voxels.ts
+++ b/ts/src/renderer/three/Voxels.ts
@@ -99,8 +99,8 @@ namespace Renderer {
 							sample[x][y] !== undefined &&
 							DevModeScene.pointerInsideMap(tileX + x, tileY + y, { width, height })
 						) {
-							let _x = tileX + x;
-							let _z = tileY + y;
+							let _x = tileX + x + 0.5;
+							let _z = tileY + y + 0.5;
 							let tileId = sample[x][y];
 							const height = this.calcHeight(layer);
 							const pos = { x: _x, y: height + yOffset * height, z: _z };


### PR DESCRIPTION
### Rationale for implementing this:
In order to correspond to the coordinates of threejs, have to add a 0.5 to the x and z

### Referenced Issue:


### Demo game JSON:
https://www.modd.io/play/RldHVBaxj/
