### PR TITLE
fix: undo/redo for drag to draw, wrongly order for the mat of the preview top and sides

### DIFF
--- a/ts/src/renderer/phaser/classes/devmode/CommandsController.ts
+++ b/ts/src/renderer/phaser/classes/devmode/CommandsController.ts
@@ -36,16 +36,11 @@ class CommandController implements CommandControllerProps {
 	 * command exec, if no change happened, it will not go into the history.
 	 */
 	addCommand(command: CommandEmitterProps, forceToHistory = false, history = true, mapEdit = true) {
-		const mapBeforeCommand = this.getAllTiles();
 		const oldTaroMap = JSON.stringify(taro.game.data.map.layers);
 		command.func();
 		if (history || forceToHistory) {
 			if (mapEdit && !forceToHistory) {
-				if (
-					this.map !== undefined &&
-					JSON.stringify(this.getAllTiles()) === JSON.stringify(mapBeforeCommand) &&
-					JSON.stringify(taro.game.data.map.layers) === oldTaroMap
-				) {
+				if (JSON.stringify(taro.game.data.map.layers) === oldTaroMap) {
 					return;
 				}
 			}
@@ -79,19 +74,5 @@ class CommandController implements CommandControllerProps {
 			this.commands[this.nowInsertIndex].func();
 			this.nowInsertIndex += 1;
 		}
-	}
-
-	getAllTiles(): Record<number, Record<number, number>> {
-		const nowTiles = {};
-		if (this.map) {
-			Object.entries(this.map.layer.data).map(([x, obj]) => {
-				nowTiles[x] = {};
-				Object.entries(obj).map(([y, tile]) => {
-					nowTiles[x][y] = tile.index;
-				});
-			});
-		}
-
-		return nowTiles;
 	}
 }

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -99,7 +99,7 @@ namespace Renderer {
 							case 'eraser': {
 							}
 							case 'brush': {
-								this.voxelEditor.voxelMarker.updatePreview();
+								this.voxelEditor.handleMapToolEdit();
 							}
 						}
 					}

--- a/ts/src/renderer/three/VoxelEditor.ts
+++ b/ts/src/renderer/three/VoxelEditor.ts
@@ -285,14 +285,18 @@ class VoxelEditor {
 		const nowTile = rfdc()(selectedTiles);
 		nowTile[_x][_y] = this.getTile(_x, this.voxels.calcLayersHeight(this.currentLayerIndex), _y);
 		const nowLayer = this.currentLayerIndex;
-		this.commandController.addCommand({
-			func: () => {
-				this.putTiles(_x, _y, selectedTiles, 'fitContent', 'rectangle', nowLayer);
-			},
-			undo: () => {
-				this.putTiles(_x, _y, nowTile, 'fitContent', 'rectangle', nowLayer);
-			},
-		});
+		if (!this.leftButtonDown) {
+			this.voxelMarker.updatePreview();
+		} else {
+			this.commandController.addCommand({
+				func: () => {
+					this.putTiles(_x, _y, selectedTiles, 'fitContent', 'rectangle', nowLayer);
+				},
+				undo: () => {
+					this.putTiles(_x, _y, nowTile, 'fitContent', 'rectangle', nowLayer);
+				},
+			});
+		}
 	}
 
 	floodFill(

--- a/ts/src/renderer/three/VoxelEditor.ts
+++ b/ts/src/renderer/three/VoxelEditor.ts
@@ -244,9 +244,7 @@ class VoxelEditor {
 			}
 		}
 		this.voxels.updateLayer(voxels, layer, true, isPreview);
-		//console.log('left button down', this.leftButtonDown, 'isPreview', isPreview, 'local', local);
-		if ((!local && !isPreview) || (local && isPreview && this.leftButtonDown)) {
-			//console.log('send edit left button down', this.leftButtonDown);
+		if (!local && !isPreview) {
 			const data: { edit: MapEditTool['edit'] } = {
 				edit: {
 					size: brushSize,
@@ -259,7 +257,6 @@ class VoxelEditor {
 				},
 			};
 			if (this.prevData === undefined || JSON.stringify(this.prevData) !== JSON.stringify(data)) {
-				console.log('send edit', data, this.prevData);
 				taro.network.send<'edit'>('editTile', data);
 				this.prevData = data;
 			}

--- a/ts/src/renderer/three/Voxels.ts
+++ b/ts/src/renderer/three/Voxels.ts
@@ -129,9 +129,9 @@ namespace Renderer {
 				curLength += voxelData.sidesIndices.length;
 				geometry.addGroup(curLength, voxelData.topIndices.length, 1);
 				curLength += voxelData.topIndices.length;
-				geometry.addGroup(curLength, voxelData.previewTopIndices.length, 2);
-				curLength += voxelData.previewTopIndices.length;
-				geometry.addGroup(curLength, voxelData.previewSidesIndices.length, 3);
+				geometry.addGroup(curLength, voxelData.previewSidesIndices.length, 2);
+				curLength += voxelData.previewSidesIndices.length;
+				geometry.addGroup(curLength, voxelData.previewTopIndices.length, 3);
 
 				const mesh = new THREE.Mesh(geometry, [mat1, mat2, mat1Preview, mat2Preview]);
 


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
