### PR TITLE
fix: add key: 0 to element wont work

### DIFF
--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -3618,7 +3618,6 @@ var ActionComponent = TaroEntity.extend({
 						var key = self._script.param.getValue(action.key, vars);
 						var value = self._script.param.getValue(action.value, vars);
 						var object = self._script.param.getValue(action.object, vars);
-
 						if (object && key && value) {
 							object[key] = value;
 						}
@@ -3630,7 +3629,7 @@ var ActionComponent = TaroEntity.extend({
 						var value = self._script.param.getValue(action.value, vars);
 						var object = self._script.param.getValue(action.object, vars);
 
-						if (object && key && value) {
+						if (object && key && (value || value === 0)) {
 							object[key] = parseFloat(value);
 						}
 


### PR DESCRIPTION
### Rationale for implementing this:
value 0 cant pass this check, and actions wont work
if (object && key && value)  {
	object[key] = parseFloat(value);
}

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
