### PR TITLE
fix issue where `Item.use()` was not called on client

### DIFF
--- a/src/gameClasses/Item.js
+++ b/src/gameClasses/Item.js
@@ -238,12 +238,6 @@ var Item = TaroEntityPhysics.extend({
 			this._stats.ownerUnitId = null;
 
 			if (this._stats.oldOwnerUnitId) {
-				if (taro.isClient) {
-					if (oldOwner._stats) {
-						oldOwner._stats.currentItemId = null;
-					}
-				}
-
 				this._stats.oldOwnerUnitId = null;
 			}
 

--- a/src/gameClasses/Unit.js
+++ b/src/gameClasses/Unit.js
@@ -1978,8 +1978,8 @@ var Unit = TaroEntityPhysics.extend({
 		// independent of currentItemIndex change, set currentItem. null is empty slot
 		// use currentItem to set the _stats property for currentItemId
 		// important for item drop/pickup/remove
-		const currentItem = taro.$(this._stats.itemIds[currentItemIndex]) || null;
-		this._stats.currentItemId = currentItem ? currentItem.id() : null;
+
+		this._stats.currentItemId = this._stats.itemIds[currentItemIndex] || null;
 
 		// client log of item state after pickup will still show 'dropped'. Currently state has not finished updating. It IS 'selected'/'unselected'
 


### PR DESCRIPTION
* when Unit first loads into game, selected Item was affected
* when Unit dropped Item from another slot (drag to drop is new and old drop logic assumed selected slot == dropping slot)