### PR TITLE
3D: Remove camera onChange callback registration on sprite creation

### DIFF
--- a/ts/src/renderer/three/Sprite.ts
+++ b/ts/src/renderer/three/Sprite.ts
@@ -22,14 +22,6 @@ namespace Renderer {
 				});
 				this.sprite = new THREE.Mesh(geometry, material);
 				this.add(this.sprite);
-
-				const renderer = Renderer.Three.instance();
-				renderer.camera.onChange(() => {
-					if (this.billboard) {
-						this.faceCamera(renderer.camera);
-						this.correctZOffsetBasedOnCameraAngle();
-					}
-				});
 			}
 
 			setBillboard(billboard: boolean, camera: Camera) {


### PR DESCRIPTION
To see if this improves the bug that lowers the fps with a compounding effect whenever a unit's body size is changed.