### PR TITLE
fix: new items which can be merged still need to trigger the unitPicksUpItem

### DIFF
--- a/src/gameClasses/Unit.js
+++ b/src/gameClasses/Unit.js
@@ -1299,16 +1299,17 @@ var Unit = TaroEntityPhysics.extend({
 				}
 
 				if (item && isItemAnEntity) {
-
 					// if this item is picked up (or even just a portion), trigger thisItemIsPickedUp
-					if (!persistedItem && (totalQuantityTakenFromItem > 0 || removeQueued)) { // using removeQueued instead of returnQueued as removeQueued ensures that the item is an entity
-						 // temporarily increase quantity of item to pass the qty at the moment of picking up
+					if (!persistedItem && (totalQuantityTakenFromItem > 0 || removeQueued)) {
+						// using removeQueued instead of returnQueued as removeQueued ensures that the item is an entity
+						// temporarily increase quantity of item to pass the qty at the moment of picking up
 						item._stats.quantity += totalQuantityTakenFromItem;
 						const triggerParams = {
 							unitId: self.id(),
-							itemId: item.id()
+							itemId: item.id(),
 						};
 						item.script.trigger('thisItemIsPickedUp', triggerParams); // this entity (item)
+						taro.script.trigger('unitPicksUpItem', triggerParams); // unit picked item
 						item._stats.quantity -= totalQuantityTakenFromItem; // restore the correct quantity
 					}
 					if (removeQueued) {
@@ -1360,19 +1361,18 @@ var Unit = TaroEntityPhysics.extend({
 
 					this.setCurrentItem(); // this MUST come after item.streamUpdateData
 
-					
 					if (!persistedItem) {
 						taro.game.lastCreatedItemId = item.id(); // this is necessary in case item isn't a new instance, but an existing item getting quantity updated
-						
+
 						const triggerParams = {
 							unitId: self.id(),
-							itemId: item.id()
+							itemId: item.id(),
 						};
-						
+
 						self.script.trigger('thisUnitPicksUpItem', triggerParams); // this entity (unit)
-						taro.script.trigger('unitPicksUpItem', triggerParams); // unit picked item	
+						taro.script.trigger('unitPicksUpItem', triggerParams); // unit picked item
 					}
-					
+
 					return true;
 				} else {
 					return false;

--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -553,7 +553,7 @@ var ParameterComponent = TaroEntity.extend({
 						var player = self.getValue(text.player, vars);
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
-						var quests = player.quests;
+						var quests = player?.quests;
 						returnValue = quests?.active[gameId][questId] !== undefined;
 
 						break;


### PR DESCRIPTION
### Rationale for implementing this:
pick up new items which can be merged wont trigger the unitPicksUpItem event

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
