### PR TITLE
fix: add quests to the auto merged streamUpdateData

### DIFF
--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -4430,36 +4430,21 @@ var TaroEntity = TaroObject.extend({
 						switch (attrName) {
 							case 'quests':
 								var gameId = taro.game.data.defaultData._id;
-								if (typeof newValue === 'string') {
-									if (this.quests.active[gameId][newValue] !== undefined) {
-										delete this.quests.active[gameId][newValue];
-									} else {
-										this.quests.completed[gameId] = this.quests.completed[gameId].filter((v) => v !== newValue);
+								Object.entries(newValue).map(([questId, v], idx) => {
+									if (v.completed === true) {
+										delete this.quests.active[gameId][questId];
+										this.quests.completed[gameId].push(questId);
+										return;
 									}
-								} else {
-									if (newValue.complete) {
-										var questsId = newValue.complete;
-										this.quests.completed[gameId].push(questsId);
-										if (this.quests.active[gameId][questsId] !== undefined) {
-											delete this.quests.active[gameId][questsId];
-										}
-									} else {
-										var keys = Object.keys(newValue);
-										if (keys.length === 1) {
-											var questId = keys[0];
-											if (this.quests.active[gameId][questId] === undefined) {
-												this.quests.active[gameId][questId] = newValue[questId];
-											} else {
-												Object.entries(newValue[questId]).map(([k, v]) => {
-													this.quests.active[gameId][questId][k] = v;
-												});
-											}
-										} else {
-											this.quests = newValue;
-										}
+									if (v.name !== undefined) {
+										this.quests.active[gameId][questId] = v;
+										return;
 									}
-								}
-								console.log(this);
+									if (v.progress !== undefined) {
+										this.quests.active[gameId][questId].progress = v.progress;
+										return;
+									}
+								});
 								break;
 							case 'anim':
 								var animationId = newValue;
@@ -4562,7 +4547,11 @@ var TaroEntity = TaroObject.extend({
 			value = data[key];
 
 			// need to include variables here, otherwise only the latest variable is sent to client streamUpdateData
-			if (['attributes', 'attributesMin', 'attributesMax', 'attributesRegenerateRate', 'variables'].includes(key)) {
+			if (
+				['attributes', 'attributesMin', 'attributesMax', 'attributesRegenerateRate', 'variables', 'quests'].includes(
+					key
+				)
+			) {
 				// some data need to merge instead of overwriting they key. otherwise, we'll only be able to send the last attribute added.
 				// for example, if server calls queueStreamData for Speed and HP attributes, HP will overwrite Speed as they share same key ("attributes")
 				// this._streamDataQueued[key] = {...this._streamDataQueued[key], ...value};

--- a/src/gameClasses/components/quest/QuestComponent.js
+++ b/src/gameClasses/components/quest/QuestComponent.js
@@ -37,7 +37,7 @@ var QuestComponent = TaroEntity.extend({
 					self._entity.streamUpdateData([
 						{
 							quests: {
-								complete: questId,
+								[questId]: { completed: true },
 							},
 						},
 					]);
@@ -57,7 +57,7 @@ var QuestComponent = TaroEntity.extend({
 		}
 		var questObj = self._entity.quests;
 		if (questObj.completed[gameId].includes(questId)) {
-			questObj.completed[gameId] = questObj.completed[gameId].filter(v => v !== questId);
+			questObj.completed[gameId] = questObj.completed[gameId].filter((v) => v !== questId);
 			if (taro.isServer) {
 				self._entity.streamUpdateData([
 					{


### PR DESCRIPTION
### Rationale for implementing this:
bc we only streamUpdateData after merged, if we didnt merge the quests object, it will only send the latest quests actions object to the clients, not all the action objects.

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
