### PR TITLE
fix: try_init everywhere

### DIFF
--- a/src/gameClasses/components/quest/QuestComponent.js
+++ b/src/gameClasses/components/quest/QuestComponent.js
@@ -6,7 +6,6 @@ var QuestComponent = TaroEntity.extend({
 		var self = this;
 		self._entity = entity;
 		var gameId = taro.game.data.defaultData._id;
-		// TODO handle the default value here
 		if (self._entity.quests.active[gameId] === undefined) {
 			self._entity.quests.active[gameId] = {};
 		}

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -1207,6 +1207,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'removeQuestForPlayer':
 						var player = self._script.param.getValue(action.player, vars);
+						player.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						if (
@@ -1230,6 +1231,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'addQuestToPlayer':
 						var player = self._script.param.getValue(action.player, vars);
+						player.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var name = self._script.param.getValue(action.name, vars);
 						var gameId = taro.game.data.defaultData._id;
@@ -1254,6 +1256,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'completeQuest':
 						var player = self._script.param.getValue(action.player, vars);
+						player.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						var newObj = player.quests;
@@ -1274,6 +1277,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'setQuestProgress':
 						var player = self._script.param.getValue(action.player, vars);
+						player.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var progress = self._script.param.getValue(action.progress, vars);
 

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -1207,7 +1207,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'removeQuestForPlayer':
 						var player = self._script.param.getValue(action.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						if (
@@ -1231,7 +1231,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'addQuestToPlayer':
 						var player = self._script.param.getValue(action.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var name = self._script.param.getValue(action.name, vars);
 						var gameId = taro.game.data.defaultData._id;
@@ -1256,7 +1256,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'completeQuest':
 						var player = self._script.param.getValue(action.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						var newObj = player.quests;
@@ -1277,7 +1277,7 @@ var ActionComponent = TaroEntity.extend({
 
 					case 'setQuestProgress':
 						var player = self._script.param.getValue(action.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self._script.param.getValue(action.questId, vars);
 						var progress = self._script.param.getValue(action.progress, vars);
 

--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -473,6 +473,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getQuestObject':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var quests = player.quests;
 						var gameId = taro.game.data.defaultData._id;
@@ -484,6 +485,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getAllActiveQuestObjectsInThisMap':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var quests = player.quests;
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
@@ -495,6 +497,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getAllActiveQuestObjects':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var quests = player.quests;
 						if (quests && quests.active) {
 							returnValue = quests.active;
@@ -504,6 +507,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getQuestProgress':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var quests = player.quests;
 						var gameId = taro.game.data.defaultData._id;
@@ -515,6 +519,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'isQuestProgressCompleted':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var quests = player.quests;
 						var gameId = taro.game.data.defaultData._id;
@@ -571,6 +576,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'isQuestActive':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						var quests = player?.quests;
@@ -580,6 +586,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'isQuestCompleted':
 						var player = self.getValue(text.player, vars);
+						player.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						var quests = player.quests;

--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -473,7 +473,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getQuestObject':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var quests = player.quests;
 						var gameId = taro.game.data.defaultData._id;
@@ -485,7 +485,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getAllActiveQuestObjectsInThisMap':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var quests = player.quests;
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
@@ -497,7 +497,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getAllActiveQuestObjects':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var quests = player.quests;
 						if (quests && quests.active) {
 							returnValue = quests.active;
@@ -507,7 +507,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'getQuestProgress':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var quests = player.quests;
 						var gameId = taro.game.data.defaultData._id;
@@ -519,7 +519,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'isQuestProgressCompleted':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var quests = player.quests;
 						var gameId = taro.game.data.defaultData._id;
@@ -576,7 +576,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'isQuestActive':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						var quests = player?.quests;
@@ -586,7 +586,7 @@ var ParameterComponent = TaroEntity.extend({
 
 					case 'isQuestCompleted':
 						var player = self.getValue(text.player, vars);
-						player.quest.init(player);
+						player?.quest.init(player);
 						var questId = self.getValue(text.questId, vars);
 						var gameId = taro.game.data.defaultData._id;
 						var quests = player.quests;


### PR DESCRIPTION
### Rationale for implementing this:
quest component may not auto init somehow, just try_init everywhere to keep it safe

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
