### PR TITLE
`return` before `TaroEntity.updateBody()` call if `.setState()` is redundant 

### DIFF
--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -173,6 +173,9 @@ var TaroEntity = TaroObject.extend({
 
 		this.script?.trigger('entityStateChanged');
 
+		if (self.previousState === newState) {
+			return;
+		}
 		self.previousState = newState;
 		self.updateBody(defaultData);
 	},


### PR DESCRIPTION
return before updateBody call if state is the same
