### PR TITLE
feat: add undo/redo for regions/entities, ctrl+c for copy entities

### DIFF
--- a/ts/src/gameClasses/DeveloperMode.ts
+++ b/ts/src/gameClasses/DeveloperMode.ts
@@ -741,7 +741,7 @@ class DeveloperMode {
 				});
 		}
 
-		inGameEditor.updateRegionInReact && inGameEditor.updateRegionInReact(data);
+		inGameEditor.updateRegionInReact && !window.isStandalone && inGameEditor.updateRegionInReact(data);
 	}
 
 	editVariable(data: Record<string, VariableData>, clientId: string): void {

--- a/ts/src/renderer/three/EntityEditor.ts
+++ b/ts/src/renderer/three/EntityEditor.ts
@@ -72,6 +72,7 @@ namespace Renderer {
 				});
 
 				window.addEventListener('keydown', (event) => {
+
 					if (event.key === 'Delete' || event.key === 'Backspace') {
 						this.deleteEntity();
 					}

--- a/ts/src/renderer/three/EntityEditor.ts
+++ b/ts/src/renderer/three/EntityEditor.ts
@@ -197,7 +197,7 @@ namespace Renderer {
 						name: this.selectedEntity.taroEntity._stats.id,
 						delete: true,
 					};
-					inGameEditor.updateRegionInReact && inGameEditor.updateRegionInReact(data, 'threejs');
+					inGameEditor.updateRegionInReact && !window.isStandalone && inGameEditor.updateRegionInReact(data, 'threejs');
 				}
 				this.selectEntity(null);
 			}

--- a/ts/src/renderer/three/EntityGizmo.ts
+++ b/ts/src/renderer/three/EntityGizmo.ts
@@ -12,8 +12,6 @@ namespace Renderer {
 
 			generateEditedAction() {
 				const renderer = Three.instance();
-				const currentCamera = (this.currentCamera = renderer.camera.instance);
-				const orbit = renderer.camera.controls;
 				const control = this.control;
 				const editedEntity = control.object;
 				let editedAction = {};

--- a/ts/src/renderer/three/EntityGizmo.ts
+++ b/ts/src/renderer/three/EntityGizmo.ts
@@ -139,12 +139,12 @@ namespace Renderer {
 								Renderer.Three.instance().voxelEditor.commandController.addCommand(
 									{
 										func: () => {
-											inGameEditor.updateRegionInReact &&
-												inGameEditor.updateRegionInReact(editedAction as RegionData, 'threejs');
+											inGameEditor.updateRegionInReact && !window.isStandalone;
+											inGameEditor.updateRegionInReact(editedAction as RegionData, 'threejs');
 										},
 										undo: () => {
-											inGameEditor.updateRegionInReact &&
-												inGameEditor.updateRegionInReact(nowUndoAction as RegionData, 'threejs');
+											inGameEditor.updateRegionInReact && !window.isStandalone;
+											inGameEditor.updateRegionInReact(nowUndoAction as RegionData, 'threejs');
 										},
 									},
 									true,

--- a/ts/src/renderer/three/EntityManager.ts
+++ b/ts/src/renderer/three/EntityManager.ts
@@ -49,7 +49,12 @@ namespace Renderer {
 
 			destroyInitEntity(initEntity: InitEntity) {
 				const renderer = Three.instance();
-				renderer.entityEditor.selectEntity(null);
+				if (
+					renderer.entityEditor.selectedEntity instanceof InitEntity &&
+					renderer.entityEditor.selectedEntity.action.actionId === initEntity.action.actionId
+				) {
+					renderer.entityEditor.selectEntity(null);
+				}
 				initEntity.destroy();
 			}
 

--- a/ts/src/renderer/three/EntityManager.ts
+++ b/ts/src/renderer/three/EntityManager.ts
@@ -36,8 +36,24 @@ namespace Renderer {
 						break;
 					}
 					case 'region': {
-						entity = new Region(taroEntity._id, taroEntity._stats.ownerId, taroEntity);
-						this.regions.push(entity);
+						const renderer = Renderer.Three.instance();
+						renderer.voxelEditor.commandController.addCommand(
+							{
+								func: () => {
+									entity = new Region(taroEntity._id, taroEntity._stats.ownerId, taroEntity);
+									this.regions.push(entity);
+								},
+								undo: () => {
+									const data = {
+										name: taroEntity._stats.id,
+										delete: true,
+									};
+									inGameEditor.updateRegionInReact && !window.isStandalone && inGameEditor.updateRegionInReact(data, 'threejs');
+								},
+							},
+							true
+						);
+
 						break;
 					}
 				}

--- a/ts/src/renderer/three/InitEntity.ts
+++ b/ts/src/renderer/three/InitEntity.ts
@@ -262,7 +262,7 @@ namespace Renderer {
 							if (
 								renderer.voxelEditor.commandController.commands[
 									nowCommandCount - renderer.voxelEditor.commandController.offset
-								].cache
+								]?.cache
 							) {
 								action.actionId =
 									renderer.voxelEditor.commandController.commands[

--- a/ts/src/renderer/three/InitEntity.ts
+++ b/ts/src/renderer/three/InitEntity.ts
@@ -247,7 +247,7 @@ namespace Renderer {
 				this.visible = false;
 			}
 
-			delete(): void {
+			delete(history = true): void {
 				let editedAction: ActionData = { actionId: this.action.actionId, wasDeleted: true };
 				const nowDeleteAction = JSON.stringify(editedAction);
 				const nowAction = JSON.stringify(this.action);
@@ -285,7 +285,7 @@ namespace Renderer {
 							}, 0);
 						},
 					},
-					true
+					history
 				);
 			}
 		}

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -303,6 +303,14 @@ namespace Renderer {
 												actionId: taro.newIdHex(),
 												wasCreated: true,
 											};
+											if(entityData.action ) {
+												if(entityData.action.rotation) {
+													action.rotation = entityData.action.rotation
+												}
+												if (entityData.action.scale) {
+													action.scale = entityData.action.scale
+												}
+											}
 											if (entityData.entityType === 'unitTypes') {
 												action.player = {
 													variableName: entityData.player,
@@ -335,7 +343,7 @@ namespace Renderer {
 																		nowCommandCount - this.voxelEditor.commandController.offset
 																	].cache
 															)
-															?.delete();
+															?.delete(false);
 													},
 												},
 												true

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -120,9 +120,6 @@ namespace Renderer {
 					}
 				});
 
-				// TODO: add undo/redo
-				renderer.domElement.addEventListener('keydown', (k: KeyboardEvent) => {});
-
 				let rightClickPos: { x: number; y: number } = undefined;
 
 				let lastTime = 0;
@@ -312,8 +309,37 @@ namespace Renderer {
 													function: 'getVariable',
 												};
 											}
-											this.createInitEntity(action);
-											taro.network.send<any>('editInitEntity', action);
+											const nowAction = JSON.stringify(action);
+											this.voxelEditor.commandController.addCommand(
+												{
+													func: () => {
+														const nowCommandCount = this.voxelEditor.commandController.nowInsertIndex;
+														const nowActionObj = JSON.parse(nowAction);
+														const newId = taro.newIdHex();
+														nowActionObj.actionId = newId;
+														this.createInitEntity(nowActionObj);
+														taro.network.send<any>('editInitEntity', nowActionObj);
+														setTimeout(() => {
+															this.voxelEditor.commandController.commands[
+																nowCommandCount - this.voxelEditor.commandController.offset
+															].cache = newId;
+														}, 0);
+													},
+													undo: () => {
+														const nowCommandCount = this.voxelEditor.commandController.nowInsertIndex;
+														this.entityManager.initEntities
+															.find(
+																(v) =>
+																	v.action.actionId ===
+																	this.voxelEditor.commandController.commands[
+																		nowCommandCount - this.voxelEditor.commandController.offset
+																	].cache
+															)
+															?.delete();
+													},
+												},
+												true
+											);
 										}
 									}
 								}


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
