### PR TITLE
Fix 'is player on mobile' not working in client side scripts

### DIFF
--- a/engine/core/TaroEntity.js
+++ b/engine/core/TaroEntity.js
@@ -5109,6 +5109,7 @@ var TaroEntity = TaroObject.extend({
 						data.isUserVerified = this._stats.isUserVerified;
 						data.isUserAdmin = this._stats.isUserAdmin;
 						data.isUserMod = this._stats.isUserMod;
+						data.isMobile = this._stats.isMobile;
 					}
 
 					break;


### PR DESCRIPTION
Make the server stream a player's `isMobile` property to the client when streaming its creation. This fixes the value of `is (local player) on mobile` always being `false` when run on the client.

### Demo game JSON:
[game.json](https://github.com/user-attachments/files/15945783/game.json)
