### PR TITLE
Joystick fixes

### DIFF
--- a/src/gameClasses/components/MobileControlsComponent.js
+++ b/src/gameClasses/components/MobileControlsComponent.js
@@ -102,6 +102,8 @@ var MobileControlsComponent = TaroEntity.extend({
 
 		this.clearControls();
 
+		let joysticks = [];
+
 		Object.keys(keybindings).forEach(function (key) {
 			var keybinding = keybindings[key];
 
@@ -112,8 +114,19 @@ var MobileControlsComponent = TaroEntity.extend({
 				var y = keybinding.mobilePosition.y * 2;
 
 				self.addControl(key, x, y, keybinding, abilities);
+
+				if (key === 'movementWheel' || key == 'lookWheel' || key == 'lookAndFireWheel') {
+					joysticks.push(key);
+				}
 			}
 		});
+
+		// if only one joystick, cover entire screen
+		// we currently only support max 2 joysticks
+		if (joysticks.length == 1) {
+			let joystickZone = document.getElementById(joysticks[0] + '_joystick');
+			joystickZone.style.width = '100vw';
+		}
 	},
 
 	// add a button or stick to the virtual controller
@@ -250,6 +263,7 @@ var MobileControlsComponent = TaroEntity.extend({
 		joystickZone.id = type + '_joystick';
 		joystickZone.style.width = '50vw';
 		joystickZone.style.height = '100vh';
+		joystickZone.classList.add('joystick-zone');
 		joystickZone.style.position = 'fixed';
 
 		// placing joystick in the correct zone

--- a/src/gameClasses/components/MobileControlsComponent.js
+++ b/src/gameClasses/components/MobileControlsComponent.js
@@ -249,7 +249,7 @@ var MobileControlsComponent = TaroEntity.extend({
 		let joystickZone = document.createElement('div');
 		joystickZone.id = type + '_joystick';
 		joystickZone.style.width = '50vw';
-		joystickZone.style.height = '50vw';
+		joystickZone.style.height = '100vh';
 		joystickZone.style.position = 'fixed';
 
 		// placing joystick in the correct zone


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?
Handle adding joysticks in mobile more gracefully. It now supports adding a single joystick which covers the whole screen where previously it covered only half screen

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
