### PR TITLE
renamed trigger's name 'entityCreated' to 'thisEntityIsCreated' and a…

### DIFF
--- a/engine/components/physics/box2d/TaroEntityPhysics.js
+++ b/engine/components/physics/box2d/TaroEntityPhysics.js
@@ -50,6 +50,11 @@ var TaroEntityPhysics = TaroEntity.extend({
 
 		this._actionQueue = [];
 		this.posHistory = [];
+
+		let entityTypesThatTrigger = ['unit', 'item', 'projectile'];
+		if (entityTypesThatTrigger.includes(this._category)) {
+			taro.script.trigger('entityIsCreated', { entityId: this.id() });
+		}
 	},
 
 	updateBody: function (defaultData, isLossTolerant) {

--- a/src/gameClasses/Item.js
+++ b/src/gameClasses/Item.js
@@ -116,7 +116,7 @@ var Item = TaroEntityPhysics.extend({
 		this.scaleDimensions(this._stats.width, this._stats.height);
 
 		if (taro.isClient) {
-			this.script.trigger('entityCreated');
+			this.script.trigger('thisEntityIsCreated');
 		}
 	},
 
@@ -451,7 +451,7 @@ var Item = TaroEntityPhysics.extend({
 											streamMode: this._stats.projectileStreamMode || 0, // editor incorrectly sets streamMode to undefined when item CSP is on
 										});
 										var projectile = new Projectile(projectileData);
-										projectile.script.trigger('entityCreated');
+										// projectile.script.trigger('thisEntityIsCreated');
 										taro.game.lastCreatedProjectileId = projectile.id();
 									}
 								}

--- a/src/gameClasses/Player.js
+++ b/src/gameClasses/Player.js
@@ -170,7 +170,7 @@ var Player = TaroEntity.extend({
 			var unit = new Unit(data);
 			unit.setOwnerPlayer(self.id());
 
-			unit.script.trigger('entityCreated');
+			unit.script.trigger('thisEntityIsCreated');
 
 			// setOwner will add unitId to unitIds
 			// self._stats.unitIds.push(unit.id())

--- a/src/gameClasses/Projectile.js
+++ b/src/gameClasses/Projectile.js
@@ -110,7 +110,7 @@ var Projectile = TaroEntityPhysics.extend({
 		this.scaleDimensions(this._stats.width, this._stats.height);
 
 		if (taro.isClient) {
-			this.script.trigger('entityCreated');
+			this.script.trigger('thisEntityIsCreated');
 		}
 	},
 

--- a/src/gameClasses/Unit.js
+++ b/src/gameClasses/Unit.js
@@ -154,7 +154,7 @@ var Unit = TaroEntityPhysics.extend({
 		self.scaleDimensions(self._stats.width, self._stats.height);
 
 		if (taro.isClient) {
-			this.script.trigger('entityCreated');
+			this.script.trigger('thisEntityIsCreated');
 		}
 	},
 
@@ -1237,7 +1237,7 @@ var Unit = TaroEntityPhysics.extend({
 					item = new Item(itemData);
 					// don't trigger entityCreated if item is loaded from persisted data
 					if (!persistedItem) {
-						item.script.trigger('entityCreated');
+						item.script.trigger('thisEntityIsCreated');
 					}
 				}
 				taro.devLog('using item immediately');
@@ -1338,7 +1338,7 @@ var Unit = TaroEntityPhysics.extend({
 						// itemData.stateId = (availableSlot-1 == this._stats.currentItemIndex) ? 'selected' : 'unselected';
 						item = new Item(itemData);
 						taro.game.lastCreatedItemId = item._id;
-						item.script.trigger('entityCreated');
+						item.script.trigger('thisEntityIsCreated');
 					}
 
 					slotIndex = !isNaN(parseFloat(slotIndex)) ? slotIndex : availableSlot - 1;
@@ -1988,7 +1988,7 @@ var Unit = TaroEntityPhysics.extend({
 							var givenItem = taro.$(taro.game.lastCreatedItemId);
 							if (givenItem && givenItem.getOwnerUnit() == this) {
 								givenItem.loadPersistentData(persistedItem);
-								givenItem.script.trigger('entityCreated');
+								givenItem.script.trigger('thisEntityIsCreated');
 							}
 						}
 					}

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -2577,7 +2577,7 @@ var ActionComponent = TaroEntity.extend({
 
 								var projectile = new Projectile(data);
 								taro.game.lastCreatedProjectileId = projectile._id;
-								projectile.script.trigger('entityCreated');
+								projectile.script.trigger('thisEntityIsCreated');
 							} else {
 								if (!projectileData) {
 									throw new Error('invalid projectile data');
@@ -2704,7 +2704,7 @@ var ActionComponent = TaroEntity.extend({
 							};
 							var item = new Item(itemData);
 							taro.game.lastCreatedItemId = item._id;
-							item.script.trigger('entityCreated');
+							item.script.trigger('thisEntityIsCreated');
 						} else {
 							throw new Error('invalid item type data');
 						}
@@ -2765,7 +2765,7 @@ var ActionComponent = TaroEntity.extend({
 							};
 							var item = new Item(itemData);
 							taro.game.lastCreatedItemId = item._id;
-							item.script.trigger('entityCreated');
+							item.script.trigger('thisEntityIsCreated');
 						} else {
 							throw new Error('invalid item type data');
 						}
@@ -2819,7 +2819,7 @@ var ActionComponent = TaroEntity.extend({
 							};
 							var item = new Item(itemData);
 							taro.game.lastCreatedItemId = item._id;
-							item.script.trigger('entityCreated');
+							item.script.trigger('thisEntityIsCreated');
 						} else {
 							throw new Error('invalid item type data');
 						}

--- a/ts/src/gameClasses/DeveloperMode.ts
+++ b/ts/src/gameClasses/DeveloperMode.ts
@@ -962,7 +962,7 @@ class DeveloperMode {
 			};
 			var item = new Item(itemData);
 			taro.game.lastCreatedUnitId = item._id;
-			item.script.trigger('entityCreated');
+			item.script.trigger('thisEntityIsCreated');
 		}
 	}
 


### PR DESCRIPTION
…lso added support for global trigger 'entityIsCreated'

### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
