### PR TITLE
none value for `movementControlScheme` no longer allows movement

### DIFF
--- a/src/gameClasses/components/ControlComponent.js
+++ b/src/gameClasses/components/ControlComponent.js
@@ -175,8 +175,8 @@ var ControlComponent = TaroEntity.extend({
 						unit._stats.controls.movementControlScheme
 					);
 					const canMoveVertical = ['wasd', 'wasdRelativeToUnit'].includes(unit._stats.controls.movementControlScheme);
-					const left = (canMoveHorizontal && this.input.key.a) || this.input.key.left;
-					const right = (canMoveHorizontal && this.input.key.d) || this.input.key.right;
+					const left = canMoveHorizontal && (this.input.key.a || this.input.key.left);
+					const right = canMoveHorizontal && (this.input.key.d || this.input.key.right);
 					const up = canMoveVertical && (this.input.key.w || this.input.key.up);
 					const down = canMoveVertical && (this.input.key.s || this.input.key.down);
 					unit.ability.move(left, right, up, down);
@@ -281,8 +281,8 @@ var ControlComponent = TaroEntity.extend({
 				unit._stats.controls.movementControlScheme
 			);
 			const canMoveVertical = ['wasd', 'wasdRelativeToUnit'].includes(unit._stats.controls.movementControlScheme);
-			const left = (canMoveHorizontal && this.input.key.a) || this.input.key.left;
-			const right = (canMoveHorizontal && this.input.key.d) || this.input.key.right;
+			const left = canMoveHorizontal && (this.input.key.a || this.input.key.left);
+			const right = canMoveHorizontal && (this.input.key.d || this.input.key.right);
 			const up = canMoveVertical && (this.input.key.w || this.input.key.up);
 			const down = canMoveVertical && (this.input.key.s || this.input.key.down);
 			unit.ability.move(left, right, up, down);


### PR DESCRIPTION
previously, horizontal movement was possible with the arrow keys--but not WASD--when `movementControlScheme` was set to `none`
