### PR TITLE
Revert "fix: rotation should be also blocked when the selectedEntity do not have that rotation field

### DIFF
--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -178,7 +178,7 @@ namespace Renderer {
 											) {
 												this.entityEditor.selectEntity(initEntity);
 												taro.client.emit('block-scale', !(initEntity.action.scale || initEntity.action.height || initEntity.action.width));
-												taro.client.emit('block-rotation', (!!initEntity.isBillboard || !(initEntity.action.angle || initEntity.action.rotation)));
+												taro.client.emit('block-rotation', !!initEntity.isBillboard);
 											} else if (clickDelay < 350) {
 												console.log('showing script for entity', initEntity.action.actionId);
 												if (inGameEditor && inGameEditor.showScriptForEntity) {


### PR DESCRIPTION
### Rationale for implementing this:
the new added model may do not have the rotation

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
