### PR TITLE
fix: use entityTypeData.bodies.default.isBillboard to check is billboard or not

### DIFF
--- a/ts/src/renderer/three/InitEntity.ts
+++ b/ts/src/renderer/three/InitEntity.ts
@@ -41,7 +41,7 @@ namespace Renderer {
 					defaultHeight = this.defaultHeight = entityTypeData.bodies?.default?.height;
 					defaultDepth = this.defaultDepth = entityTypeData.bodies?.default?.depth;
 				}
-				this.isBillboard = (((entityTypeData?.isBillboard) ?? entityTypeData?.bodies?.default?.isBillboard) ?? false);
+				this.isBillboard = entityTypeData?.bodies?.default?.isBillboard ?? false;
 				const renderer = Renderer.Three.instance();
 				let body: (Renderer.Three.AnimatedSprite | Renderer.Three.Model) & { entity: InitEntity };
 				if (entityTypeData.is3DObject) {
@@ -142,7 +142,7 @@ namespace Renderer {
 
 			update() {
 				if (this.isBillboard) {
-					this.body.update(0)
+					this.body.update(0);
 				}
 			}
 


### PR DESCRIPTION
### Rationale for implementing this:
the isBillboard from editor-side seems is a little buggy
e.g.
one model only have one default body, which its isbillBoard is false, but another field( isBillboard ) we use, is true, will edit the editor side as well

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
