### PR TITLE
fix: use defaultData.defaultRenderer instead

### DIFF
--- a/ts/engine/components/physics/box2d/distsWrapper/box2dwasmWrapper.ts
+++ b/ts/engine/components/physics/box2d/distsWrapper/box2dwasmWrapper.ts
@@ -110,7 +110,7 @@ const box2dwasmWrapper: PhysicsDistProps = {
 				if (!component.renderer) {
 					const scale = taro.physics._scaleRatio;
 					let debugDrawer;
-					if (taro.game.data.defaultRenderer !== '3d') {
+					if (taro.game.data.defaultData.defaultRenderer !== '3d') {
 						const canvas = taro.renderer.scene.getScene('Game');
 						ctx = canvas.add.graphics().setDepth(9999);
 						ctx.setScale(scale);

--- a/ts/types/GameComponent.d.ts
+++ b/ts/types/GameComponent.d.ts
@@ -143,7 +143,6 @@ declare class GameComponent extends TaroEntity {
 		scripts: Record<string, ScriptData>;
 		defaultData: any;
 		map: MapData;
-		defaultRenderer: string;
 		unitTypes: Record<string, EntityData>;
 		projectileTypes: Record<string, EntityData>;
 		itemTypes: Record<string, EntityData>;


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
