### PR TITLE
fix: should not trigger canvas keyEvent whenever focus on other dom

### DIFF
--- a/ts/src/renderer/three/Camera.ts
+++ b/ts/src/renderer/three/Camera.ts
@@ -121,6 +121,9 @@ namespace Renderer {
 				};
 
 				window.addEventListener('keypress', (evt) => {
+					if(!Utils.isFocusOnPlayPage()) {
+						return;
+					}
 					if (evt.key === '~') {
 						this.debugMode = !this.debugMode;
 						this.setEditorMode(this.debugMode);

--- a/ts/src/renderer/three/EntityEditor.ts
+++ b/ts/src/renderer/three/EntityEditor.ts
@@ -93,6 +93,9 @@ namespace Renderer {
 				});
 
 				window.addEventListener('keydown', (event) => {
+					if(!Utils.isFocusOnPlayPage()) {
+						return;
+					}
 					const renderer = Renderer.Three.instance();
 					if (event.key === 'Delete' || event.key === 'Backspace') {
 						this.deleteEntity();

--- a/ts/src/renderer/three/EntityGizmo.ts
+++ b/ts/src/renderer/three/EntityGizmo.ts
@@ -209,6 +209,9 @@ namespace Renderer {
 				});
 
 				window.addEventListener('keyup', function (event) {
+					if(!Utils.isFocusOnPlayPage()) {
+						return;
+					}
 					switch (event.key) {
 						case 'Shift':
 							control.setTranslationSnap(null);

--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -495,7 +495,7 @@ namespace Renderer {
 					}
 				});
 
-				window.addEventListener('mouseup', (event: MouseEvent) => {
+				renderer.domElement.addEventListener('mouseup', (event: MouseEvent) => {
 					if (event.button === 1) {
 						return;
 					}

--- a/ts/src/renderer/three/Utils.ts
+++ b/ts/src/renderer/three/Utils.ts
@@ -19,6 +19,13 @@ namespace Renderer {
 				return `${url}?v=1`;
 			}
 
+			export function isFocusOnPlayPage() {
+				if (document.activeElement.className !== 'play-page') {
+					return false;
+				}
+				return true;
+			}
+
 			export function fillRect(
 				ctx: CanvasRenderingContext2D,
 				x: number,


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
