### PR TITLE
chore: only init audioCtx in client-side

### DIFF
--- a/src/gameClasses/components/SoundComponent.js
+++ b/src/gameClasses/components/SoundComponent.js
@@ -9,7 +9,7 @@ var SoundComponent = TaroEntity.extend({
 		self.preLoadedSounds = {};
 		self.preLoadedMusic = {};
 		self.cachedAudioBuffer = {};
-		self.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+		self.audioCtx = taro.isClient ? new (window.AudioContext || window.webkitAudioContext)() : null;
 		if (taro.isClient) {
 			var soundSetting = self.getItem('sound');
 			var musicSetting = self.getItem('music');


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
