### PR TITLE
fix: should still emit the pointermove when there is no follow target

### DIFF
--- a/ts/src/renderer/three/Renderer.ts
+++ b/ts/src/renderer/three/Renderer.ts
@@ -1131,7 +1131,7 @@ namespace Renderer {
 				window.lastRequestAnimationFrameId = requestAnimationFrame(this.render.bind(this));
 				taro.client.emit('tick');
 				// Call this function before rendering
-				if (this.camera.target) {
+				if (this.camera) {
 					const worldPos = this.camera.getWorldPoint(this.pointer);
 					const x = Utils.worldToPixel(worldPos.x);
 					const y = Utils.worldToPixel(worldPos.z);


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
