### PR TITLE
fix: should not show or hide, whenever it's already in the backpack

### DIFF
--- a/src/gameClasses/Item.js
+++ b/src/gameClasses/Item.js
@@ -147,6 +147,11 @@ var Item = TaroEntityPhysics.extend({
 				}
 			}
 		}
+		// check if it's in backpack first
+		let owner = self.getOwnerUnit();
+		if (owner && self._stats.slotIndex >= owner._stats.inventorySize) {
+			return;
+		}
 		// if body exists and item is not hidden, show
 		if (body && body.type != 'none') {
 			TaroEntityPhysics.prototype.updateBody.call(self, initTransform);


### PR DESCRIPTION
### Rationale for implementing this:
fixed an issue which cause that whenever u put the selected item (which also have unselected body) into the backpack, the unselected body still exist

it's bc that the moving item into backpack would trigger .hide() for it, it's right, but after hide(), it also trigger the setState('unselected') and then call the .show() again
![image](https://github.com/user-attachments/assets/eb8ff4be-5941-434e-990f-9e3d47f1040a)

what i did is only to add an extra checking before show() and hide() in setState func, check whether it's already in backpack or not

### Referenced Issue:
![image](https://github.com/user-attachments/assets/0f57011a-520d-4f34-a4cd-ae357bfb1289)


### Demo game JSON:
[unselected issue.txt](https://github.com/user-attachments/files/16745922/unselected.issue.txt)
how to test
- select the star first
- move it into the backpack
- see if it disappear
