### PR TITLE
fix: should use the width and height after scaled not default one

### DIFF
--- a/src/gameClasses/Unit.js
+++ b/src/gameClasses/Unit.js
@@ -159,8 +159,8 @@ var Unit = TaroEntityPhysics.extend({
 			taro.script.trigger('entityCreatedGlobal', { entityId: this.id() });
 			this.script.trigger('entityCreated');
 		}
-		this.width(self._stats.currentBody.width);
-		this.height(self._stats.currentBody.height);
+		this.width(self._stats.width);
+		this.height(self._stats.height);
 	},
 
 	shouldRenderAttribute: function (attribute) {


### PR DESCRIPTION
### Rationale for implementing this:
Why is this needed? What does it help accomplish?

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
A demonstration of the added function in a game. Ideally, this also also showcases a situation in which the added action/function/variable is useful.
