### PR TITLE
fix: should update the width and height after scaled

### DIFF
--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -4067,11 +4067,8 @@ var ActionComponent = TaroEntity.extend({
 					case 'changeScaleOfEntityBody':
 						var entity = self._script.param.getValue(action.entity, vars);
 						var scale = self._script.param.getValue(action.scale, vars);
-						var fixedScale = parseFloat(scale).toFixed(2);
 						if (entity && self.entityCategories.indexOf(entity._category) > -1 && !isNaN(scale)) {
-							entity.width(entity.width() * fixedScale);
-							entity.height(entity.height() * fixedScale);
-							entity.streamUpdateData([{ scaleBody: fixedScale }]);
+							entity.streamUpdateData([{ scaleBody: parseFloat(scale).toFixed(2) }]);
 						}
 						break;
 

--- a/src/gameClasses/components/script/ActionComponent.js
+++ b/src/gameClasses/components/script/ActionComponent.js
@@ -4067,8 +4067,11 @@ var ActionComponent = TaroEntity.extend({
 					case 'changeScaleOfEntityBody':
 						var entity = self._script.param.getValue(action.entity, vars);
 						var scale = self._script.param.getValue(action.scale, vars);
+						var fixedScale = parseFloat(scale).toFixed(2);
 						if (entity && self.entityCategories.indexOf(entity._category) > -1 && !isNaN(scale)) {
-							entity.streamUpdateData([{ scaleBody: parseFloat(scale).toFixed(2) }]);
+							entity.width(entity.width() * fixedScale);
+							entity.height(entity.height() * fixedScale);
+							entity.streamUpdateData([{ scaleBody: fixedScale }]);
 						}
 						break;
 

--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -1273,6 +1273,7 @@ var ParameterComponent = TaroEntity.extend({
 						break;
 
 					case 'entityWidth':
+						// return the size of physics bodies, not the sprite one
 						if (entity && self._entity.script.action.entityCategories.indexOf(entity._category) > -1) {
 							// returnValue = entity._aabb.width;
 							returnValue = entity.width() * (isNaN(entity._stats.scaleBody) ? 1 : entity._stats.scaleBody);
@@ -1282,6 +1283,7 @@ var ParameterComponent = TaroEntity.extend({
 						break;
 
 					case 'entityHeight':
+						// return the size of physics bodies, not the sprite one
 						if (entity && self._entity.script.action.entityCategories.indexOf(entity._category) > -1) {
 							// returnValue = entity._aabb.height;
 							returnValue = entity.height() * (isNaN(entity._stats.scaleBody) ? 1 : entity._stats.scaleBody);

--- a/src/gameClasses/components/script/ParameterComponent.js
+++ b/src/gameClasses/components/script/ParameterComponent.js
@@ -1275,7 +1275,7 @@ var ParameterComponent = TaroEntity.extend({
 					case 'entityWidth':
 						if (entity && self._entity.script.action.entityCategories.indexOf(entity._category) > -1) {
 							// returnValue = entity._aabb.width;
-							returnValue = entity.width();
+							returnValue = entity.width() * (isNaN(entity._stats.scaleBody) ? 1 : entity._stats.scaleBody);
 							// console.log("entityWidth", returnValue);
 						}
 
@@ -1284,7 +1284,7 @@ var ParameterComponent = TaroEntity.extend({
 					case 'entityHeight':
 						if (entity && self._entity.script.action.entityCategories.indexOf(entity._category) > -1) {
 							// returnValue = entity._aabb.height;
-							returnValue = entity.height();
+							returnValue = entity.height() * (isNaN(entity._stats.scaleBody) ? 1 : entity._stats.scaleBody);
 						}
 
 						break;


### PR DESCRIPTION
### Rationale for implementing this:
now the changeScaleOfEntityBody action does change the size of the physics body, but doesnt update the width and height in it

### Referenced Issue:
Github issue of the requested feature

### Demo game JSON:
[🟥Bug Entity Width and Height_202496_144.json](https://github.com/user-attachments/files/16898408/Bug.Entity.Width.and.Height_202496_144.json)
#### how to test
- follow the step in the game hud