### PR TITLE
A Star with Obstacle Dodging

### DIFF
--- a/src/gameClasses/components/MapComponent.js
+++ b/src/gameClasses/components/MapComponent.js
@@ -1,12 +1,22 @@
-var MapComponent = TaroEntity.extend({
-	classId: 'MapComponent',
-	componentId: 'map',
+class MapComponent extends TaroEntity {
+	classId = 'MapComponent';
+	componentId = 'map';
+	constructor() {
+		super();
 
-	init: function () {
-		//
-	},
+		/**
+		 * @type {Array<boolean>}
+		 */
+		this.AStarPathfindingMap;
 
-	load: function (data) {
+		/**
+		 * @type {Array<boolean>}
+		 */
+		this.wallMap;
+
+	}
+
+	load(data) {
 		var self = this;
 
 		self.data = data;
@@ -31,8 +41,10 @@ var MapComponent = TaroEntity.extend({
 			});
 		}
 		self.updateWallMapData();
-	},
-	createRegions: function () {
+		this.updateAStarPathfindingData();
+	}
+
+	createRegions() {
 		var regions = {};
 		for (var i in taro.game.data.variables) {
 			var variable = taro.game.data.variables[i];
@@ -50,9 +62,9 @@ var MapComponent = TaroEntity.extend({
 				}
 			}
 		}
-	},
+	}
 
-	updateWallMapData: function () {
+	updateWallMapData() {
 		// call this after in-game map tile editing
 		var self = this;
 
@@ -62,16 +74,71 @@ var MapComponent = TaroEntity.extend({
 
 		this.wallMap = rfdc()(wallLayer?.data); // cache a copy of wall layer's data
 		this.wallMap = this.wallMap?.map((value) => value != 0);
-	},
+	}
 
-	tileIsWall: function (x, y) {
+	/**
+	 * Must create wallMap before this
+	 * Execute everytime before an A star path is generate
+	 * Avoid execute within a short time < 250ms to avoid duplicate update
+	 */
+	updateAStarPathfindingData() {
+		const entityType = ["unit", "item", "projectile"];
+		const vertexPosShift = [
+			{ x: -1, y: -1 },
+			{ x: 1, y: -1 },
+			{ x: -1, y: 1 },
+			{ x: 1, y: 1 }
+		];
+		const tileWidth = taro.scaleMapDetails.tileWidth;
+		const mapData = taro.map.data;
+		this.AStarPathfindingMap = Array(this.wallMap.length).fill(false);
+
+		entityType.forEach(type => {
+			taro.$$(type).forEach(entity => {
+				const currentBody = entity._stats.currentBody;
+				if (currentBody.type == "static" || currentBody.type == "kinematic") {
+					if (currentBody.fixtures[0].isSensor === false) {
+						const entityVertices = [];
+						vertexPosShift.forEach(shift => {
+							entityVertices.push({
+								x: entity._translate.x + (currentBody.width / 2 * Math.cos(entity._rotate.z) * shift.x - currentBody.height / 2 * Math.sin(entity._rotate.z) * shift.y),
+								y: entity._translate.y + (currentBody.width / 2 * Math.sin(entity._rotate.z) * shift.x + currentBody.height / 2 * Math.cos(entity._rotate.z) * shift.y)
+							});
+						});
+						const topLeftVertex = {
+							x: Math.min(...entityVertices.map(vertex => vertex.x)),
+							y: Math.min(...entityVertices.map(vertex => vertex.y))
+						};
+						const bottomRightVertex = {
+							x: Math.max(...entityVertices.map(vertex => vertex.x)),
+							y: Math.max(...entityVertices.map(vertex => vertex.y))
+						};
+						for (let j = Math.clamp(Math.floor(topLeftVertex.y / tileWidth), 0, mapData.height - 1); j <= Math.clamp(Math.floor(bottomRightVertex.y / tileWidth), 0, mapData.height - 1); j++) {
+							for (let i = Math.clamp(Math.floor(topLeftVertex.x / tileWidth), 0, mapData.width - 1); i <= Math.clamp(Math.floor(bottomRightVertex.x / tileWidth), 0, mapData.width - 1); i++) {
+								this.AStarPathfindingMap[j * mapData.width + i] = true;
+							}
+						}
+					}
+				}
+			});
+		});
+		for (const tile in this.AStarPathfindingMap) {
+			this.AStarPathfindingMap[tile] = this.AStarPathfindingMap[tile] || this.wallMap[tile];
+		}
+	}
+
+	tileIsWall(x, y) {
 		return this.wallMap[y * this.data.width + x];
-	},
+	}
 
-	getDimensions: function () {
+	tileIsBlocked(x, y) {
+		return this.AStarPathfindingMap[y * this.data.width + x];
+	}
+
+	getDimensions() {
 		return {};
-	},
-});
+	}
+}
 
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
 	module.exports = MapComponent;

--- a/src/gameClasses/components/MapComponent.js
+++ b/src/gameClasses/components/MapComponent.js
@@ -96,9 +96,12 @@ class MapComponent extends TaroEntity {
 		entityType.forEach(type => {
 			taro.$$(type).forEach(entity => {
 				const currentBody = entity._stats.currentBody;
+				// only continue if the body is static / kinematic and it is not sensor
 				if (currentBody.type == "static" || currentBody.type == "kinematic") {
 					if (currentBody.fixtures[0].isSensor === false) {
 						const entityVertices = [];
+
+						// get bounding box
 						vertexPosShift.forEach(shift => {
 							entityVertices.push({
 								x: entity._translate.x + (currentBody.width / 2 * Math.cos(entity._rotate.z) * shift.x - currentBody.height / 2 * Math.sin(entity._rotate.z) * shift.y),
@@ -113,6 +116,8 @@ class MapComponent extends TaroEntity {
 							x: Math.max(...entityVertices.map(vertex => vertex.x)),
 							y: Math.max(...entityVertices.map(vertex => vertex.y))
 						};
+
+						// fill occupying tiles
 						for (let j = Math.clamp(Math.floor(topLeftVertex.y / tileWidth), 0, mapData.height - 1); j <= Math.clamp(Math.floor(bottomRightVertex.y / tileWidth), 0, mapData.height - 1); j++) {
 							for (let i = Math.clamp(Math.floor(topLeftVertex.x / tileWidth), 0, mapData.width - 1); i <= Math.clamp(Math.floor(bottomRightVertex.x / tileWidth), 0, mapData.width - 1); i++) {
 								this.AStarPathfindingMap[j * mapData.width + i] = true;
@@ -122,6 +127,8 @@ class MapComponent extends TaroEntity {
 				}
 			});
 		});
+
+		// combine with wallMap
 		for (const tile in this.AStarPathfindingMap) {
 			this.AStarPathfindingMap[tile] = this.AStarPathfindingMap[tile] || this.wallMap[tile];
 		}

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -16,13 +16,13 @@ class AStarPathfindingComponent extends TaroEntity {
 	 * @param {number} y
 	 * @returns {{path: [], ok: boolean}}
 	 * Use .path to get return array with tiled x and y coordinates of the path (Start node exclusive)
-	 * if target position is not reachable (no road to go / inside object [wall / static entity / kinematic entity]) path will include tiled x and y passed only
+	 * if target position is not reachable (no road to go / inside obstacle [wall / static entity / kinematic entity]) path will include tiled x and y passed only
 	 * if the unit already at the target location, .path return empty array
 	 *
 	 * Use .ok to check if path correctly generated
 	 * .ok return true if .path is found or the unit already at the target location
-	 * .ok return false if the target location is inside a object, not reachable
-	 * if there is no object between the start position and the end position, it will return the end position in .path, and return true in .ok
+	 * .ok return false if the target location is inside an obstacle, not reachable
+	 * if there is no obstacle between the start position and the end position, it will return the end position in .path, and return true in .ok
 	 */
 	getAStarPath(x, y) {
 		// Update pathfindable tile data
@@ -47,7 +47,7 @@ class AStarPathfindingComponent extends TaroEntity {
 		let returnValue = { path: [{ ...targetTilePosition }], ok: false };
 
 		if (map.tileIsBlocked(targetTilePosition.x, targetTilePosition.y)) {
-			// teminate if the target position is object
+			// teminate if the target position is obstacle
 			return returnValue;
 		}
 
@@ -120,10 +120,10 @@ class AStarPathfindingComponent extends TaroEntity {
 				}
 
 				if (map.tileIsBlocked(newPosition.x, newPosition.y)) continue; // node is blocked, discard
-				// if new position is not goal, prune it if object overlaps
+				// if new position is not goal, prune it if obstacle overlaps
 				let shouldPrune = false;
 				for (let i = 1; i <= averageTileShift; i++) {
-					// check 8 direction of average tile shift to see will unit overlap with object at that node
+					// check 8 direction of average tile shift to see will unit overlap with obstacle at that node
 					let cornersHaveWallCurrent =
 						map.tileIsBlocked(minNode.current.x + i, minNode.current.y) ||
 						map.tileIsBlocked(minNode.current.x - i, minNode.current.y) ||
@@ -145,7 +145,7 @@ class AStarPathfindingComponent extends TaroEntity {
 						map.tileIsBlocked(newPosition.x - i, newPosition.y + i) ||
 						map.tileIsBlocked(newPosition.x + i, newPosition.y - i);
 
-					// Idea: avoid hitting outer corners of object(dodge by going outer), and allow unit to walk next to objects
+					// Idea: avoid hitting outer corners of obstacle(dodge by going outer), and allow unit to walk next to obstacles
 					shouldPrune =
 						(cornersHaveWallNew || sidesHaveWallNew) &&
 						(cornersHaveWallCurrent || sidesHaveWallCurrent) &&
@@ -316,7 +316,7 @@ class AStarPathfindingComponent extends TaroEntity {
 				startPos[primaryDirection] * Math.sign(diff[primaryDirection]) <=
 				endPos[primaryDirection] * Math.sign(diff[primaryDirection])
 			) {
-				// check tiles within unit size to see if they are occupied by object
+				// check tiles within unit size to see if they are occupied by obstacle
 				for (let j = -maxHalfTileShift; j <= maxHalfTileShift; j++) {
 					for (let i = -maxHalfTileShift; i <= maxHalfTileShift; i++) {
 						let x = Math.floor((startPos.x + i * tileWidth / 4) / tileWidth);

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -260,49 +260,72 @@ class AStarPathfindingComponent extends TaroEntity {
 		this._entity.script.trigger('entityAStarPathFindingFailed', triggerParam);
 	}
 
-	/**
-	 * 
-	 * @param {number} targetX 
-	 * @param {number} targetY 
-	 * @param {number=} fromX
-	 * @param {number=} fromY
-	 * @returns 
-	 * Values are world space coordinate instead of tile coordinate
-	 */
+	// /**
+	//  * 
+	//  * @param {number} targetX 
+	//  * @param {number} targetY 
+	//  * @param {number=} fromX
+	//  * @param {number=} fromY
+	//  * @returns 
+	//  * Values are world space coordinate instead of tile coordinate
+	//  */
+	// aStarIsPositionBlocked(targetX, targetY, fromX, fromY) {
+	// 	const unit = this._entity;
+	// 	const xTune = [0, -1, 1, -1, 1];
+	// 	const yTune = [0, -1, -1, 1, 1];
+	// 	// center, top-left, top-right, bottom-left, bottom-right
+	// 	const unitWidth = unit._stats.currentBody.width;
+	// 	const unitHeight = unit._stats.currentBody.height;
+	// 	if (!fromX) fromX = unit._translate.x;
+	// 	if (!fromY) fromY = unit._translate.y;
+	// 	const maxBodySizeShift = Math.sqrt(unitWidth * unitWidth + unitHeight * unitHeight) / 2;
+	// 	for (let i = 0; i < 5; i++) {
+	// 		taro.raycaster.raycastLine(
+	// 			{
+	// 				x: (fromX + maxBodySizeShift * xTune[i]) / taro.physics.getScaleRatio(),
+	// 				y: (fromY + maxBodySizeShift * yTune[i]) / taro.physics.getScaleRatio(),
+	// 			},
+	// 			{
+	// 				x: (targetX + maxBodySizeShift * xTune[i]) / taro.physics.getScaleRatio(),
+	// 				y: (targetY + maxBodySizeShift * yTune[i]) / taro.physics.getScaleRatio(),
+	// 			}
+	// 		);
+	// 		for (let i = 0; i < taro.game.entitiesCollidingWithLastRaycast.length; i++) {
+	// 			const entity = taro.game.entitiesCollidingWithLastRaycast[i];
+	// 			const blockedByWall = entity?._category == 'wall';
+	// 			const blockedByEntity = (
+	// 				entity?._stats?.currentBody?.type == "static" ||
+	// 				entity?._stats?.currentBody?.type == "kinematic"
+	// 			) && entity?._stats?.currentBody?.fixtures[0]?.isSensor === false;
+	// 			if (blockedByWall || blockedByEntity) {
+	// 				return true;
+	// 			}
+	// 		}
+	// 	}
+	// 	return false;
+	// }
+
 	aStarIsPositionBlocked(targetX, targetY, fromX, fromY) {
 		const unit = this._entity;
-		const xTune = [0, -1, 1, -1, 1];
-		const yTune = [0, -1, -1, 1, 1];
-		// center, top-left, top-right, bottom-left, bottom-right
-		const unitWidth = unit._stats.currentBody.width;
-		const unitHeight = unit._stats.currentBody.height;
-		if (!fromX) fromX = unit._translate.x;
-		if (!fromY) fromY = unit._translate.y;
 		const maxBodySizeShift = Math.sqrt(unitWidth * unitWidth + unitHeight * unitHeight) / 2;
-		for (let i = 0; i < 5; i++) {
-			taro.raycaster.raycastLine(
-				{
-					x: (fromX + maxBodySizeShift * xTune[i]) / taro.physics.getScaleRatio(),
-					y: (fromY + maxBodySizeShift * yTune[i]) / taro.physics.getScaleRatio(),
-				},
-				{
-					x: (targetX + maxBodySizeShift * xTune[i]) / taro.physics.getScaleRatio(),
-					y: (targetY + maxBodySizeShift * yTune[i]) / taro.physics.getScaleRatio(),
-				}
-			);
-			for (let i = 0; i < taro.game.entitiesCollidingWithLastRaycast.length; i++) {
-				const entity = taro.game.entitiesCollidingWithLastRaycast[i];
-				const blockedByWall = entity?._category == 'wall';
-				const blockedByEntity = (
-					entity?._stats?.currentBody?.type == "static" ||
-					entity?._stats?.currentBody?.type == "kinematic"
-				) && entity?._stats?.currentBody?.fixtures[0]?.isSensor === false;
-				if (blockedByWall || blockedByEntity) {
-					return true;
-				}
+		const tileWidth = taro.scaleMapDetails.tileWidth;
+		const direction = {
+			x: targetX - fromX,
+			y: targetY - fromY
+		};
+		let j = fromY;
+		let i = fromX;
+		while (
+			j * direction.y <= targetY * direction.y ||
+			i * direction.x <= targetY * direction.x
+		) {
+			if (j * direction.y <= targetY * direction.y) {
+				// j += tileWidth * direction.y;
+			}
+			if (i * direction.x <= targetY * direction.x) {
+				// i += tileWidth * direction.x;
 			}
 		}
-		return false;
 	}
 
 	aStarPathIsBlocked() {

--- a/src/gameClasses/components/unit/AStarPathfindingComponent.js
+++ b/src/gameClasses/components/unit/AStarPathfindingComponent.js
@@ -308,6 +308,8 @@ class AStarPathfindingComponent extends TaroEntity {
 	aStarPathIsBlocked() {
 		const unit = this._entity;
 		const tileWidth = taro.scaleMapDetails.tileWidth;
+
+		// current position to closest node of path
 		const nextPathIsBlocked = this.path.length > 0 && this.aStarIsPositionBlocked(
 			Math.floor(unit._translate.x / tileWidth) * tileWidth,
 			Math.floor(unit._translate.y / tileWidth) * tileWidth,
@@ -315,6 +317,8 @@ class AStarPathfindingComponent extends TaroEntity {
 			Math.floor(this.path[0].y / tileWidth) * tileWidth
 		);
 		if (nextPathIsBlocked) return true;
+
+		// other segments in the path
 		for (let i = 0; i < this.path.length - 1; i++) {
 			if (this.aStarIsPositionBlocked(
 				Math.floor(this.path[i].x / tileWidth) * tileWidth,


### PR DESCRIPTION
### Rationale for implementing this:
Allow AI to dodge non movable obstacle instead of bumping into them

### Update
- Added logic to prevent A Star generate path with obstacle in between
- Added logic to prevent A Star prettification false prettify path with obstacle in between
- Convert mapComponent into es6 class
- A Star no longer use raycaster

### Referenced Issue
m0dE's request

### Demo game JSON:
[game.json](https://github.com/user-attachments/files/17023383/game.json)
To Test:
LMB: command unit to move
RMB: randomly spawn obstacle (potato: projectile, box: unit, stone: item) <either static or kinematic>

## Demo Video:
https://github.com/user-attachments/assets/6aca54e7-0e10-4d7d-b028-8bfae37119fd


